### PR TITLE
Boto has built-in support for loading multiple named accounts, use it.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,12 +26,12 @@ Installation
 Developing and running tests
 =============================
 
-The test suite can be run via setup.py as follows:
-::   
+The test suite can be run via setup.py as follows::
+
     python -m unittest discover
-    
-    or
-    
+
+or::
+
     python setup.py test
 
 
@@ -40,7 +40,7 @@ Example Usage
 
 Bootstrap-cfn uses `fabric <http://www.fabfile.org/>`_, so if your ``$CWD`` is the root directory of bootstrap-cfn then you can run::
 
-    fab application:courtfinder aws:prod environment:dev config:/path/to/courtfinder-dev.yaml cfn_create
+    fab application:courtfinder aws:my_project_prod environment:dev config:/path/to/courtfinder-dev.yaml cfn_create
 
 
 If your ``$CWD`` is anywhere else, you need to pass in a path to particular fabric file::
@@ -63,17 +63,15 @@ Example Configuration
 AWS Account Configuration
 ++++++++++++++++++++++++++
 
-This tool can support many AWS accounts, for example, you may have separate *development* and *production* accounts, however you still want to deploy the same stack to each, this can be achieved by adding multiple accounts to the ``~/.config.yaml`` file. You'll notice from the **Example Usage** section above the ``aws:dev`` flag, this can be changed accordingly.
+This tool needs AWS credentials to create stacks and the credentials should be placed in the ``~/.aws/credentials`` file (which is the same one used by the AWS CLI tools). You should create named profiles like this (and the section names should match up with what you specify to the fabric command with the ``aws:my_project_prod`` flag) ::
 
-::
 
-    provider_zones:
-      dev:
-        aws_access_key_id: 'AKIAI***********'
-        aws_secret_access_key: '*******************************************'
-      prod:
-        aws_access_key_id: 'AKIAI***********'
-        aws_secret_access_key: '*******************************************'
+    [my_project_dev]
+    aws_access_key_id = AKIAI***********
+    aws_secret_access_key = *******************************************
+    [my_project_prod]
+    aws_access_key_id = AKIAI***********
+    aws_secret_access_key = *******************************************
 
 
 Project specific YAML file

--- a/bootstrap_cfn/cloudformation.py
+++ b/bootstrap_cfn/cloudformation.py
@@ -15,19 +15,7 @@ class Cloudformation:
     def __init__(self, aws_profile_name, aws_region_name='eu-west-1'):
         self.aws_profile_name = aws_profile_name
         self.aws_region_name = aws_region_name
-        try:
-            self.conn_cfn = boto.cloudformation.connect_to_region(
-                self.aws_region_name,
-                profile_name=self.aws_profile_name
-            )
-        except NoAuthHandlerFound:
-            print "[ERROR] No AWS credentials"
-            print "Create an ~/.aws/credentials file by following this layout:\n\n" + \
-                "  http://boto.readthedocs.org/en/latest/boto_config_tut.html#credentials"
-            sys.exit(1)
-        except ProfileNotFoundError, e:
-            print e
-            sys.exit(1)
+        self.conn_cfn = utils.connect_to_aws(boto.cloudformation, self)
 
     def create(self, stack_name, template_body):
         stack = self.conn_cfn.create_stack(stack_name=stack_name,
@@ -66,10 +54,7 @@ class Cloudformation:
             return []
         scaling_group_id = scaling_group[0].physical_resource_id
 
-        asc = autoscale.connect_to_region(
-            self.aws_region_name,
-            profile_name=self.aws_profile_name
-        )
+        asc = utils.connect_to_aws(autoscale, self)
 
         # get the instance IDs for all instances in the scaling group
         instances = asc.get_all_groups(names=[scaling_group_id])[0].instances

--- a/bootstrap_cfn/cloudformation.py
+++ b/bootstrap_cfn/cloudformation.py
@@ -2,22 +2,31 @@ import sys
 import boto.cloudformation
 import boto.ec2
 from boto.ec2 import autoscale
+from boto.exception import NoAuthHandlerFound
+from boto.provider import ProfileNotFoundError
 from bootstrap_cfn import utils
 
 class Cloudformation:
 
     conn_cfn = None
-    config = None
+    aws_region_name = None
+    aws_profile_name = None
 
-    def __init__(self, config):
-        self.config = config
-        if self.config.aws_access is not None and self.config.aws_secret is not None:
+    def __init__(self, aws_profile_name, aws_region_name='eu-west-1'):
+        self.aws_profile_name = aws_profile_name
+        self.aws_region_name = aws_region_name
+        try:
             self.conn_cfn = boto.cloudformation.connect_to_region(
-                region_name=self.config.aws_region,
-                aws_access_key_id=self.config.aws_access,
-                aws_secret_access_key=self.config.aws_secret)
-        else:
+                self.aws_region_name,
+                profile_name=self.aws_profile_name
+            )
+        except NoAuthHandlerFound:
             print "[ERROR] No AWS credentials"
+            print "Create an ~/.aws/credentials file by following this layout:\n\n" + \
+                "  http://boto.readthedocs.org/en/latest/boto_config_tut.html#credentials"
+            sys.exit(1)
+        except ProfileNotFoundError, e:
+            print e
             sys.exit(1)
 
     def create(self, stack_name, template_body):
@@ -56,9 +65,12 @@ class Cloudformation:
             print 'No scaling group found'
             return []
         scaling_group_id = scaling_group[0].physical_resource_id
-        asc = autoscale.connect_to_region(self.config.aws_region,
-                                          aws_access_key_id=self.config.aws_access,
-                                          aws_secret_access_key=self.config.aws_secret)
+
+        asc = autoscale.connect_to_region(
+            self.aws_region_name,
+            profile_name=self.aws_profile_name
+        )
+
         # get the instance IDs for all instances in the scaling group
         instances = asc.get_all_groups(names=[scaling_group_id])[0].instances
         return instances

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -6,31 +6,6 @@ import yaml
 import bootstrap_cfn.errors as errors
 from copy import deepcopy
 
-
-class AWSConfig:
-
-    aws_access = None
-    aws_secret = None
-    aws_region = 'eu-west-1'
-
-    def __init__(self, account, fp=None):
-        if fp:
-            if os.path.exists(fp):
-                f = open(fp).read()
-            else:
-                raise IOError
-        else:
-            f = open(os.path.expanduser("~") + "/.config.yaml").read()
-
-        try:
-            if f:
-                d = yaml.load(f)['provider_zones']
-                self.aws_access = d[account]['aws_access_key_id']
-                self.aws_secret = d[account]['aws_secret_access_key']
-        except KeyError:
-            raise
-
-
 class ProjectConfig:
 
     config = None

--- a/bootstrap_cfn/ec2.py
+++ b/bootstrap_cfn/ec2.py
@@ -16,19 +16,8 @@ class EC2:
     def __init__(self, aws_profile_name, aws_region_name='eu-west-1'):
         self.aws_profile_name = aws_profile_name
         self.aws_region_name = aws_region_name
-        try:
-            self.conn_ec2 = boto.ec2.connect_to_region(
-                self.aws_region_name,
-                profile_name=self.aws_profile_name
-            )
-        except NoAuthHandlerFound:
-            print "[ERROR] No AWS credentials"
-            print "Create an ~/.aws/credentials file by following this layout:\n\n" + \
-                "  http://boto.readthedocs.org/en/latest/boto_config_tut.html#credentials"
-            sys.exit(1)
-        except ProfileNotFoundError, e:
-            print e
-            sys.exit(1)
+
+        self.conn_ec2 = utils.connect_to_aws(boto.ec2, self)
 
         self.cfn = cloudformation.Cloudformation(
             aws_profile_name=aws_profile_name,

--- a/bootstrap_cfn/errors.py
+++ b/bootstrap_cfn/errors.py
@@ -1,6 +1,8 @@
+import sys
+
 class BootstrapCfnError(Exception):
     def __init__(self, msg):
-        print "[ERROR] {0}: {1}".format(self.__class__.__name__, msg)
+        print >> sys.stderr,  "[ERROR] {0}: {1}".format(self.__class__.__name__, msg)
 
 class CfnConfigError(BootstrapCfnError):
     pass

--- a/bootstrap_cfn/errors.py
+++ b/bootstrap_cfn/errors.py
@@ -8,6 +8,19 @@ class CfnConfigError(BootstrapCfnError):
 class CfnTimeoutError(BootstrapCfnError):
     pass
 
+class NoCredentialsError(BootstrapCfnError):
+    def __init__(self):
+        super(NoCredentialsErrror, self).__init__(
+            "Create an ~/.aws/credentials file by following this layout:\n\n" +
+            "  http://boto.readthedocs.org/en/latest/boto_config_tut.html#credentials"
+        )
+
+class ProfileNotFoundError(BootstrapCfnError):
+    def __init__(self, profile_name):
+        super(ProfileNotFoundError, self).__init__(
+            "'{0}' not found in ~/.aws/credentials".format(profile_name)
+        )
+
 class SaltStateError(BootstrapCfnError):
     pass
 

--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -88,6 +88,9 @@ def _validate_fabric_env():
     if not hasattr(env, 'stack_passwords'):
         env.stack_passwords = {}
 
+    if not hasattr(env, 'aws_region'):
+        env.aws_region = 'eu-west-1'
+
 
 def get_config():
     _validate_fabric_env()
@@ -101,7 +104,7 @@ def get_config():
 
 def get_connection(klass):
     _validate_fabric_env()
-    return klass(env.aws)
+    return klass(env.aws, env.aws_region)
 
 @task
 def cfn_delete(force=False):

--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -85,8 +85,12 @@ def _validate_fabric_env():
         print "\n[ERROR] Please specify a config file, e.g 'config:/tmp/sample-application.yaml'"
         sys.exit(1)
 
-    if not hasattr(env, 'stack_passwords'):
-        env.stack_passwords = {}
+    if hasattr(env, 'stack_passwords') and env.stack_passwords is not None:
+        if not os.path.exists(env.stack_passwords):
+            print >> sys.stderr, "\n[ERROR] Passwords file '{0}' doesn't exist!".format(env.stack_passwords)
+            sys.exit(1)
+    else:
+        env.stack_passwords = None
 
     if not hasattr(env, 'aws_region'):
         env.aws_region = 'eu-west-1'

--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -3,7 +3,8 @@
 import sys
 import random
 import yaml
-from bootstrap_cfn.config import AWSConfig, ProjectConfig, ConfigParser
+
+from bootstrap_cfn.config import ProjectConfig, ConfigParser
 from bootstrap_cfn.cloudformation import Cloudformation
 from bootstrap_cfn.ec2 import EC2
 from bootstrap_cfn.iam import IAM
@@ -100,8 +101,7 @@ def get_config():
 
 def get_connection(klass):
     _validate_fabric_env()
-    aws_config = AWSConfig(env.aws)
-    return klass(aws_config)
+    return klass(env.aws)
 
 @task
 def cfn_delete(force=False):

--- a/bootstrap_cfn/iam.py
+++ b/bootstrap_cfn/iam.py
@@ -2,6 +2,8 @@ import boto.iam
 from boto.exception import NoAuthHandlerFound
 from boto.provider import ProfileNotFoundError
 
+from bootstrap_cfn import utils
+
 class IAM:
 
     conn_cfn = None
@@ -12,19 +14,7 @@ class IAM:
         self.aws_profile_name = aws_profile_name
         self.aws_region_name = aws_region_name
 
-        try:
-            self.conn_iam = boto.iam.connect_to_region(
-                region_name=self.aws_region_name,
-                profile_name=self.aws_profile_name
-            )
-        except NoAuthHandlerFound:
-            print "[ERROR] No AWS credentials"
-            print "Create an ~/.aws/credentials file by following this layout:\n\n" + \
-                "  http://boto.readthedocs.org/en/latest/boto_config_tut.html#credentials"
-            sys.exit(1)
-        except ProfileNotFoundError, e:
-            print e
-            sys.exit(1)
+        self.conn_iam = utils.connect_to_aws(boto.iam, self)
 
     def upload_ssl_certificate(self, ssl_config, stack_name):
         for cert_name, ssl_data in ssl_config.items():

--- a/bootstrap_cfn/iam.py
+++ b/bootstrap_cfn/iam.py
@@ -1,19 +1,29 @@
 import boto.iam
+from boto.exception import NoAuthHandlerFound
+from boto.provider import ProfileNotFoundError
 
 class IAM:
 
     conn_cfn = None
-    config = None
+    aws_region_name = None
+    aws_profile_name = None
 
-    def __init__(self, config):
-        self.config = config
-        if self.config.aws_access is not None and self.config.aws_secret is not None:
+    def __init__(self, aws_profile_name, aws_region_name='eu-west-1'):
+        self.aws_profile_name = aws_profile_name
+        self.aws_region_name = aws_region_name
+
+        try:
             self.conn_iam = boto.iam.connect_to_region(
-                region_name=self.config.aws_region,
-                aws_access_key_id=self.config.aws_access,
-                aws_secret_access_key=self.config.aws_secret)
-        else:
+                region_name=self.aws_region_name,
+                profile_name=self.aws_profile_name
+            )
+        except NoAuthHandlerFound:
             print "[ERROR] No AWS credentials"
+            print "Create an ~/.aws/credentials file by following this layout:\n\n" + \
+                "  http://boto.readthedocs.org/en/latest/boto_config_tut.html#credentials"
+            sys.exit(1)
+        except ProfileNotFoundError, e:
+            print e
             sys.exit(1)
 
     def upload_ssl_certificate(self, ssl_config, stack_name):

--- a/bootstrap_cfn/utils.py
+++ b/bootstrap_cfn/utils.py
@@ -1,5 +1,10 @@
+import boto.exception
+import boto.provider
+import sys
 import time
+
 import bootstrap_cfn.errors as errors
+
 
 def timeout(timeout, interval):
     def decorate(func):
@@ -15,3 +20,16 @@ def timeout(timeout, interval):
                 time.sleep(interval)
         return wrapper
     return decorate
+
+
+def connect_to_aws(module, instance):
+    try:
+        conn = module.connect_to_region(
+            region_name=instance.aws_region_name,
+            profile_name=instance.aws_profile_name
+        )
+        return conn
+    except boto.exception.NoAuthHandlerFound:
+        raise errors.NoCredentialsError()
+    except boto.provider.ProfileNotFoundError as e:
+        raise errors.ProfileNotFoundError(instance.aws_profile_name)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import unittest
-from bootstrap_cfn.config import ProjectConfig, AWSConfig, ConfigParser
+from bootstrap_cfn.config import ProjectConfig, ConfigParser
 import bootstrap_cfn.errors as errors
 from testfixtures import compare
 
@@ -35,31 +35,6 @@ class TestConfig(unittest.TestCase):
         self.assertEquals(
             config.config['rds']['db-master-password'],
             'testpassword')
-
-    def test_aws_config_invalid_file(self):
-        '''
-        Test the AWS config file errors on invalid file
-        '''
-
-        with self.assertRaises(IOError):
-            AWSConfig('dev', 'tests/config_unknown.yaml')
-
-    def test_aws_config_valid(self):
-        '''
-        Test the AWS config file is setup correctly
-        '''
-        config = AWSConfig('dev', 'tests/config.yaml')
-        self.assertEquals(config.aws_access, 'AKIAI***********')
-        self.assertEquals(
-            config.aws_secret,
-            '*******************************************')
-
-    def test_aws_config_invalid_env(self):
-        '''
-        Test the AWS config file errors on invalid environment
-        '''
-        with self.assertRaises(KeyError):
-            AWSConfig('unknown', 'tests/config.yaml')
 
 
 class TestConfigParser(unittest.TestCase):


### PR DESCRIPTION
This closes #1. This has two benefits:
1. we can delete some code \o/
2. We can store the credentials in a way compatible with AWS's own sdk/cli tools

This will cause everyone to fail with 'you don't have credentials' properly - I'll add something to the readme showing the new config format
