### PR TITLE
Move timeout logic

### DIFF
--- a/bootstrap_cfn/cloudformation.py
+++ b/bootstrap_cfn/cloudformation.py
@@ -2,6 +2,7 @@ import sys
 import boto.cloudformation
 import boto.ec2
 from boto.ec2 import autoscale
+from bootstrap_cfn import utils
 
 
 class Cloudformation:
@@ -37,6 +38,9 @@ class Cloudformation:
             return True
         return False
 
+    def wait_for_stack_done(self, stack_id, timeout=3600, interval=30):
+        return utils.timeout(timeout, interval)(self.stack_done)(stack_id)
+
     def get_last_stack_event(self, stack_id):
         return self.conn_cfn.describe_stack_events(stack_id)[0]
 
@@ -68,3 +72,6 @@ class Cloudformation:
         ''' Returns True if stack not found'''
         stacks = self.conn_cfn.describe_stacks()
         return stack_name not in [s.stack_name for s in stacks]
+
+    def wait_for_stack_missing(self, stack_id, timeout=3600, interval=30):
+        return utils.timeout(timeout, interval)(self.stack_missing)(stack_id)

--- a/bootstrap_cfn/errors.py
+++ b/bootstrap_cfn/errors.py
@@ -4,3 +4,6 @@ class BootstrapCfnError(Exception):
 
 class CfnConfigError(BootstrapCfnError):
     pass
+
+class CfnTimeoutError(BootstrapCfnError):
+    pass

--- a/bootstrap_cfn/utils.py
+++ b/bootstrap_cfn/utils.py
@@ -1,0 +1,17 @@
+import time
+import bootstrap_cfn.errors as errors
+
+def timeout(timeout, interval):
+    def decorate(func):
+        def wrapper(*args, **kwargs):
+            attempts = 0
+            while True:
+                result = func(*args, **kwargs)
+                if result:
+                    return result
+                if attempts >= timeout / interval:
+                    raise errors.CfnTimeoutError("Timeout in {0}".format(func.__name__))
+                attempts += 1
+                time.sleep(interval)
+        return wrapper
+    return decorate

--- a/fabfile.py
+++ b/fabfile.py
@@ -113,16 +113,8 @@ def cfn_delete(force=False):
 
     # Wait for stacks to delete
     print 'Waiting for stack to delete.'
-    attempts = 0
-    while True:
-        if cfn.stack_missing(stack_name):
-           print "Stack successfully deleted"
-           break
-        if attempts >= TIMEOUT / RETRY_INTERVAL:
-            print '[ERROR] Stack deletion timed out'
-            sys.exit(1)
-        attempts += 1
-        time.sleep(RETRY_INTERVAL)
+    cfn.wait_for_stack_missing(stack_name)
+    print "Stack successfully deleted"
     if 'ssl' in cfn_config.data:
         iam = IAM(aws_config)
         iam.delete_ssl_certificate(cfn_config.ssl(), stack_name)
@@ -148,16 +140,7 @@ def cfn_create():
 
     # Wait for stacks to complete
     print 'Waiting for stack to complete.'
-    attempts = 0
-    while True:
-        if cfn.stack_done(stack):
-            break
-        if attempts >= TIMEOUT / RETRY_INTERVAL:
-            print '[ERROR] Stack creation timed out'
-            sys.exit(1)
-        attempts += 1
-        time.sleep(RETRY_INTERVAL)
-
+    cfn.wait_for_stack_done(stack)
     print 'Stacks completed, checking results.'
     stack_evt = cfn.get_last_stack_event(stack)
     print '{0}: {1}'.format(stack_evt.stack_name, stack_evt.resource_status)


### PR DESCRIPTION
This moves the timeout logic out of the fabric file and into a
reusable decorator. It also adds some tests to the timeout logic
and an error class for timeouts.

Adding this because I also want to add a wait_for_ssh re #30 
