### PR TITLE
Wait for SSH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version unreleased
+
+ * Move timeout logic from fabric file into utility decorator.
+ * Add wait_for_ssh function to the bootstrap commands. This ensures ssh is up before we bootstrap.
+
 ## Version 0.1
 
  * Build CloudFormation stack for a simple Web Application with a single ELB, EC2 instances and RDS

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,10 @@ If your ``$CWD`` is anywhere else, you need to pass in a path to particular fabr
 - **environment:dev** - The ``dev`` section will be read from the projects YAML file (line 1 in the example below)
 - **config:/path/to/file.yaml** - The location to the project YAML file
 
+If you also want to bootstrap the salt master and minions, you can do this::
+
+    fab application:courtfinder aws:prod environment:dev config:/path/to/courtfinder-dev.yaml cfn_create install_master install_minions
+
 Example Configuration
 ======================
 AWS Account Configuration

--- a/bootstrap_cfn/cloudformation.py
+++ b/bootstrap_cfn/cloudformation.py
@@ -4,7 +4,6 @@ import boto.ec2
 from boto.ec2 import autoscale
 from bootstrap_cfn import utils
 
-
 class Cloudformation:
 
     conn_cfn = None

--- a/bootstrap_cfn/ec2.py
+++ b/bootstrap_cfn/ec2.py
@@ -1,6 +1,8 @@
 import sys
 import boto.ec2
 from bootstrap_cfn import cloudformation
+from bootstrap_cfn import ssh
+from bootstrap_cfn import utils
 
 class EC2:
 
@@ -69,3 +71,12 @@ class EC2:
         if remove_master:
             instances.remove(self.get_master_instance(stack_name_or_id))
         return instances
+
+    def is_ssh_up_on_all_instances(self, stack_id):
+        instances = self.get_instance_public_ips(self.cfn.get_stack_instance_ids(stack_id))
+        if all([ssh.is_ssh_up(i) for i in instances]):
+            return True
+        return False
+
+    def wait_for_ssh(self, stack_id, timeout=300, interval=30):
+        return utils.timeout(timeout, interval)(self.is_ssh_up_on_all_instances)(stack_id)

--- a/bootstrap_cfn/ssh.py
+++ b/bootstrap_cfn/ssh.py
@@ -1,0 +1,15 @@
+import paramiko
+from paramiko.ssh_exception import AuthenticationException, BadHostKeyException
+import socket
+
+def is_ssh_up(host):
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    try:
+        client.connect(host, username='nobody', password='badpassword', timeout=5)
+        return True
+    except (AuthenticationException, BadHostKeyException):
+        return True
+    except socket.error:
+        pass
+    return False

--- a/fabfile.py
+++ b/fabfile.py
@@ -212,8 +212,8 @@ def install_minions():
     stack_name = get_stack_name()
     aws_config, cfn, cfn_config = get_config()
     ec2 = EC2(aws_config)
-    stack_name = get_stack_name()
-
+    print "Waiting for SSH on all instances..."
+    ec2.wait_for_ssh(stack_name)
     candidates = get_candidate_minions()
     existing_minions = ec2.get_minions(stack_name)
     to_install = list(set(candidates).difference(set(existing_minions)))
@@ -244,9 +244,9 @@ def install_master():
     stack_name = get_stack_name()
     aws_config, cfn, cfn_config = get_config()
     ec2 = EC2(aws_config)
-    stack_name = get_stack_name()
+    print "Waiting for SSH on all instances..."
+    ec2.wait_for_ssh(stack_name)
     instance_ids = cfn.get_stack_instance_ids(stack_name)
-    stack_name = get_stack_name()
     master_inst = ec2.get_master_instance(stack_name)
     master = master_inst.id if master_inst else random.choice(instance_ids)
     master_prv_ip = ec2.get_instance_private_ips([master])[0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ PyYAML==3.11
 boto==2.36.0
 mock==1.0.1
 testfixtures==4.1.2
+paramiko


### PR DESCRIPTION
This adds a function to wait for ssh on all instances. This is hooked into the bootstrap commands so that we only bootstrap once we can connect with ssh on all instances in the stack.
