### PR TITLE
Fix bootstrap ordering

### DIFF
--- a/bootstrap_cfn/ec2.py
+++ b/bootstrap_cfn/ec2.py
@@ -73,7 +73,14 @@ class EC2:
         return instances
 
     def is_ssh_up_on_all_instances(self, stack_id):
+        '''
+        Returns False if no instances found
+        Returns False if any instance is not available over SSH
+        Returns True if all found instances available over SSH
+        '''
         instances = self.get_instance_public_ips(self.cfn.get_stack_instance_ids(stack_id))
+        if not instances:
+            return False
         if all([ssh.is_ssh_up(i) for i in instances]):
             return True
         return False

--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -228,7 +228,9 @@ def install_minions():
     ec2.set_instance_tags(to_install, {'SaltMasterPrvIP': master_prv_ip})
     for inst_ip in public_ips:
         env.host_string = 'ubuntu@%s' % inst_ip
-        sudo('/usr/local/bin/ec2_tags.py')
+        sudo('wget https://raw.githubusercontent.com/ministryofjustice/bootstrap-cfn/master/scripts/bootstrap-salt.sh -O /tmp/moj-bootstrap.sh')
+        sudo('chmod 755 /tmp/moj-bootstrap.sh')
+        sudo('/tmp/moj-bootstrap.sh')
         sudo(
             'wget https://raw.githubusercontent.com/saltstack/salt-bootstrap/%s/bootstrap-salt.sh -O /tmp/bootstrap-salt.sh' %
             sha)
@@ -260,11 +262,13 @@ def install_master():
     stack_public_ips.remove(master_public_ip)
     env.host_string = 'ubuntu@%s' % master_public_ip
     sha = '6080a18e6c7c2d49335978fa69fa63645b45bc2a'
+    sudo('wget https://raw.githubusercontent.com/ministryofjustice/bootstrap-cfn/master/scripts/bootstrap-salt.sh -O /tmp/moj-bootstrap.sh')
+    sudo('chmod 755 /tmp/moj-bootstrap.sh')
+    sudo('/tmp/moj-bootstrap.sh')
     sudo(
         'wget https://raw.githubusercontent.com/saltstack/salt-bootstrap/%s/bootstrap-salt.sh -O /tmp/bootstrap-salt.sh' %
         sha)
     sudo('chmod 755 /tmp/bootstrap-salt.sh')
-    sudo('/usr/local/bin/ec2_tags.py')
     sudo(
         '/tmp/bootstrap-salt.sh -M -A `cat /etc/tags/SaltMasterPrvIP` git v2014.1.4')
     sudo('salt-key -y -A')

--- a/bootstrap_cfn/stacks/ec2.json
+++ b/bootstrap_cfn/stacks/ec2.json
@@ -21,9 +21,7 @@
                       "",
                       [
                         "#!/bin/bash -xe\n",
-                        "wget https://raw.githubusercontent.com/ministryofjustice/bootstrap-cfn/master/scripts/bootstrap-salt.sh -O /tmp/moj-bootstrap.sh\n",
-                        "chmod 755 /tmp/moj-bootstrap.sh\n",
-                        "/tmp/moj-bootstrap.sh "
+                        "#do nothing for now"
                       ]
                   ]
               }

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -423,9 +423,7 @@ class TestConfigParser(unittest.TestCase):
                  'BaseHostLaunchConfig': {'Type': 'AWS::AutoScaling::LaunchConfiguration',
                                           'Properties': {'UserData': {'Fn::Base64': {'Fn::Join': ['',
                                                                                                   ['#!/bin/bash -xe\n',
-                                                                                                   'wget https://raw.githubusercontent.com/ministryofjustice/bootstrap-cfn/master/scripts/bootstrap-salt.sh -O /tmp/moj-bootstrap.sh\n',
-                                                                                                   'chmod 755 /tmp/moj-bootstrap.sh\n',
-                                                                                                   '/tmp/moj-bootstrap.sh ']]}},
+                                                                                                   '#do nothing for now']]}},
                                                          'ImageId': {'Fn::FindInMap': ['AWSRegion2AMI',
                                                                                        {
                                                                                            'Ref': 'AWS::Region'},


### PR DESCRIPTION
- Ensure we wait for at least one instance before we bootstrap
- Run bootstrap from one place (fabric task)

(my thinking here is that anything that needs to be synchronous should run in the bootstrap task, LaunchConfiguration should only be used when we don't need to know the result)
