### PR TITLE
Add a script for running salt

### DIFF
--- a/bootstrap_cfn/errors.py
+++ b/bootstrap_cfn/errors.py
@@ -7,3 +7,9 @@ class CfnConfigError(BootstrapCfnError):
 
 class CfnTimeoutError(BootstrapCfnError):
     pass
+
+class SaltStateError(BootstrapCfnError):
+    pass
+
+class SaltParserError(BootstrapCfnError):
+    pass

--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -240,7 +240,6 @@ def install_minions():
         env.host_string = 'ubuntu@%s' % master_public_ip
         sudo('salt-key -y -A')
 
-
 @task
 def install_master():
     stack_name = get_stack_name()

--- a/bootstrap_cfn/salt_utils.py
+++ b/bootstrap_cfn/salt_utils.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+from bootstrap_cfn import utils
+from bootstrap_cfn import errors
+import salt
+import salt.runner
+import salt.client
+import pprint
+import time
+import sys
+
+def start_highstate(target):
+    local = salt.client.LocalClient()
+    jid = local.cmd_async(target, 'state.highstate')
+    return jid
+
+def start_state(target, state):
+    local = salt.client.LocalClient()
+    jid = local.cmd_async(target, 'state.sls', [state])
+    return jid
+
+def state_result(jid):
+    opts = salt.config.master_config('/etc/salt/master')
+    r = salt.runner.RunnerClient(opts)
+    result = r.cmd('jobs.lookup_jid', [jid])
+    if result:
+        return result
+    return False
+
+def highstate(target, timeout, interval):
+    jid = start_highstate(target)
+    res = utils.timeout(timeout, interval)(state_result)(jid)
+    return check_state_result(res)
+
+def state(target, state, timeout, interval):
+    jid = start_state(target, state)
+    res = utils.timeout(timeout, interval)(state_result)(jid)
+    return check_state_result(res)
+
+def check_state_result(result):
+    results = []
+    for ret in result.values():
+        if isinstance(ret, dict):
+            results += [v['result'] for v in ret.values()]
+        else:
+            raise errors.SaltParserError('Minion could not parse state data')
+    if all(results):
+        return True
+    else:
+        raise errors.SaltStateError('State did not execute successfully')

--- a/bootstrap_cfn/salt_utils.py
+++ b/bootstrap_cfn/salt_utils.py
@@ -47,3 +47,23 @@ def check_state_result(result):
         return True
     else:
         raise errors.SaltStateError('State did not execute successfully')
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description='Run salt states')
+    parser.add_argument('-t', dest='target', type=str,
+                       help='target', required=True)
+    parser.add_argument('-s', dest='state', type=str,
+                       help='Name of state or "highstate"', required=True)
+    parser.add_argument('-T', dest='timeout', type=float,
+                       help='Timeout to wait for state execution to finish'\
+                            'on all minions.', required=False, default = 1800)
+    parser.add_argument('-I', dest='interval', type=float,
+                       help='Interval to check for finished execution.',
+                       required=False, default=10)
+                            
+    args = parser.parse_args()
+    if args.state == "highstate":
+        highstate(args.target, args.timeout, args.interval)
+    else:
+        state(args.target, args.state, args.timeout, args.interval)

--- a/scripts/bootstrap-salt.sh
+++ b/scripts/bootstrap-salt.sh
@@ -5,12 +5,10 @@ apt-get update
 apt-get -y install python-setuptools git
 easy_install boto
 
-mkdir -p /usr/local/bin
-
+cd /usr/local && git clone https://github.com/ministryofjustice/bootstrap-cfn
 easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-wget https://raw.githubusercontent.com/ministryofjustice/bootstrap-cfn/master/scripts/ec2_tags.py -O /usr/local/bin/ec2_tags.py
-chmod 755 /usr/local/bin/ec2_tags.py
-/usr/local/bin/ec2_tags.py
+chmod 755 /usr/local/bootstrap-cfn/scripts/ec2_tags.py
+/usr/local/bootstrap-cfn/scripts/ec2_tags.py
 #wget https://raw.githubusercontent.com/saltstack/salt-bootstrap/6080a18e6c7c2d49335978fa69fa63645b45bc2a/bootstrap-salt.sh -O /tmp/bootstrap-salt.sh
 #chmod 755 /tmp/bootstrap-salt.sh
 #/tmp/bootstrap-salt.sh -X git v2014.1.4

--- a/scripts/bootstrap-salt.sh
+++ b/scripts/bootstrap-salt.sh
@@ -8,6 +8,7 @@ easy_install boto
 cd /usr/local && git clone https://github.com/ministryofjustice/bootstrap-cfn
 easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
 chmod 755 /usr/local/bootstrap-cfn/scripts/ec2_tags.py
+chmod 750 /usr/local/bootstrap-cfn/bootstrap_cfn/salt_utils.py
 /usr/local/bootstrap-cfn/scripts/ec2_tags.py
 #wget https://raw.githubusercontent.com/saltstack/salt-bootstrap/6080a18e6c7c2d49335978fa69fa63645b45bc2a/bootstrap-salt.sh -O /tmp/bootstrap-salt.sh
 #chmod 755 /tmp/bootstrap-salt.sh

--- a/tests/test_salt_util.py
+++ b/tests/test_salt_util.py
@@ -1,0 +1,69 @@
+import unittest
+import mock
+from bootstrap_cfn import errors
+import os
+import sys
+#This is a hack so that we don't need salt to run our tests
+sys.modules['salt'] = mock.Mock()
+sys.modules['salt.runner'] = mock.Mock()
+sys.modules['salt.client'] = mock.Mock()
+import salt
+from bootstrap_cfn import salt_utils
+
+class SaltUtilTestCase(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_state_result(self):
+        salt.config = mock.Mock()
+        mock_result = mock.Mock()
+        mock_config = {'cmd.return_value': {'minon1': {'state':{'result':True}}}}
+        mock_result.configure_mock(**mock_config)
+
+        mock_client = mock.Mock()
+        mock_client.return_value = mock_result
+
+        mock_runner = mock.Mock(RunnerClient=mock_client)
+
+        salt.runner = mock_runner
+        x = salt_utils.state_result('12345')
+        self.assertTrue(x)
+
+    def test_no_state_result(self):
+        salt.config = mock.Mock()
+        mock_result = mock.Mock()
+        mock_config = {'cmd.return_value': {}}
+        mock_result.configure_mock(**mock_config)
+
+        mock_client = mock.Mock()
+        mock_client.return_value = mock_result
+
+        mock_runner = mock.Mock(RunnerClient=mock_client)
+
+        salt.runner = mock_runner
+        x = salt_utils.state_result('12345')
+        self.assertFalse(x)
+
+    def test_check_state_result_good(self):
+        result = {'minon1': {'state':{'result':True}},
+                  'minion2': {'state':{'result':True}}} 
+        x = salt_utils.check_state_result(result)
+        self.assertTrue(x)
+
+    def test_check_state_result_bad(self):
+        result = {'minon1': {'state':{'result':False}},
+                  'minion2': {'state':{'result':True}}} 
+        with self.assertRaises(errors.SaltStateError):
+            salt_utils.check_state_result(result)
+
+    def test_check_state_result_parse_error(self):
+        result = {'minon1': ['SOME SALT PARSER ERROR']}
+        with self.assertRaises(errors.SaltParserError):
+            salt_utils.check_state_result(result)
+
+    def tearDown(self):
+        pass
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This adds a salt_utils module which can run salt on the master, gather and parse the results to decide if state execution succeeded. Otherwise running a salt state always produces a 0 error code.

I've deliberately not included salt as a requirement seeing as this will only run on the remote machines where salt will already be installed.
