### PR TITLE
Add CF config to salt pillar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
  * Add conditional statement in fabfile to check for ssl cert on roll back before trying to delete it.
  * Refactor fab_tasks get_config method to not return *every* config item. Also PEP8 fixes and removing unused functions.
  * Change security group input to dictionary so we can create multiple groups that reference each other.
+ * Include cloudformation config in salt pillar.
 
 ## Version 0.1
 

--- a/README.rst
+++ b/README.rst
@@ -173,6 +173,13 @@ In order to rsync your salt states to the salt master you need to add a `salt` s
     **Default value**: /srv/salt
 - **remote_pillar_dir**: Pillar root on the master.
     **Default value**: /srv/pillar
+
+The cloudformation yaml will be automatically uploaded to your pillar as cloudformation.sls. So if you include ``-cloudformation`` in your pillar top file you can do things like:
+
+::
+
+    salt-call pillar.get s3:static-bucket-name
+
 SSL certs for ELBs
 ++++++++++++++++++++
 


### PR DESCRIPTION
This uploads the stack config to cloudformtaion.sls in the salt pillar dir. This way it can be included in the pillar in the deploy repositories and referenced in the salt templates.
