### PR TITLE
Security Groups as dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  * Fix bug in wait_for_ssh when no instances are running.
  * Add conditional statement in fabfile to check for ssl cert on roll back before trying to delete it.
  * Refactor fab_tasks get_config method to not return *every* config item. Also PEP8 fixes and removing unused functions.
+ * Change security group input to dictionary so we can create multiple groups that reference each other.
 
 ## Version 0.1
 

--- a/README.rst
+++ b/README.rst
@@ -101,14 +101,15 @@ The YAML file below highlights what is possible with all the bootstrap-cfn featu
           - DeviceName: /dev/sdf
             VolumeSize: 10
         security_groups:
-          - IpProtocol: tcp
-            FromPort: 22
-            ToPort: 22
-            CidrIp: 0.0.0.0/0
-          - IpProtocol: tcp
-            FromPort: 80
-            ToPort: 80
-            CidrIp: 0.0.0.0/0
+          MySecGroup:
+            - IpProtocol: tcp
+              FromPort: 22
+              ToPort: 22
+              CidrIp: 0.0.0.0/0
+            - IpProtocol: tcp
+              FromPort: 80
+              ToPort: 80
+              CidrIp: 0.0.0.0/0
       elb:
         - name: test-dev-external
           hosted_zone: my.domain.com.

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -259,8 +259,13 @@ class ConfigParser:
         template = json.loads(pkgutil.get_data('bootstrap_cfn', 'stacks/ec2.json'))
 
         # SET SECURITY GROUPS, DEFAULT KEY AND INSTANCE TYPE
-        template['BaseHostSG']['Properties'][
-            'SecurityGroupIngress'] = self.data['ec2']['security_groups']
+        sg_t = template.pop('BaseHostSG')
+        for sg_name, sg in self.data['ec2']['security_groups'].items():
+            new_sg = deepcopy(sg_t)
+            new_sg['Properties']['SecurityGroupIngress'] = sg
+            template[sg_name] = new_sg
+
+        template['BaseHostLaunchConfig']['Properties']['SecurityGroups'] = [{'Ref': k} for k in self.data['ec2']['security_groups'].keys()]
         template['BaseHostLaunchConfig']['Properties'][
             'KeyName'] = self.data['ec2']['parameters']['KeyName']
         template['BaseHostLaunchConfig']['Properties'][

--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -248,23 +248,6 @@ def install_master():
         '/tmp/bootstrap-salt.sh -M -A `cat /etc/tags/SaltMasterPrvIP` git v2014.1.4')
     sudo('salt-key -y -A')
 
-    master_instance = ec2.get_instance_by_id(master)
-    sg_name = '{0}-salt_sg'.format(stack_name)
-    try:
-        salt_sg = ec2.get_sg(sg_name)
-    except Exception:
-        salt_sg = ec2.create_sg(sg_name)
-    existing_hosts = [x.cidr_ip for rule in salt_sg.rules for x in rule.grants]
-    print existing_hosts
-    for prv_ip in stack_ips:
-        print '\t %s/32' % prv_ip, '{0}/32'.format(prv_ip) not in existing_hosts
-        if '{0}/32'.format(prv_ip) not in existing_hosts:
-            ec2.add_minion_to_sg(salt_sg, prv_ip)
-    groups = master_instance.get_attribute('groupSet').get('groupSet')
-    groups.append(salt_sg)
-    master_instance.modify_attribute('groupSet', [x.id for x in groups])
-
-
 @task
 def rsync():
     if env.config is None:

--- a/tests/sample-project.yaml
+++ b/tests/sample-project.yaml
@@ -17,14 +17,21 @@ dev:
       - DeviceName: /dev/sdf
         VolumeSize: 10
     security_groups:
-      - IpProtocol: tcp
-        FromPort: 22
-        ToPort: 22
-        CidrIp: 0.0.0.0/0
-      - IpProtocol: tcp
-        FromPort: 80
-        ToPort: 80
-        CidrIp: 0.0.0.0/0
+      AnotherSG:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          SourceSecurityGroupName:
+            Ref: BaseHostSG
+      BaseHostSG:
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
   elb:
     - name: test-dev-external
       hosted_zone: kyrtest.pf.dsd.io.

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3,6 +3,7 @@
 import unittest
 from bootstrap_cfn.config import ProjectConfig, AWSConfig, ConfigParser
 import bootstrap_cfn.errors as errors
+from testfixtures import compare
 
 
 class TestConfig(unittest.TestCase):
@@ -431,7 +432,7 @@ class TestConfigParser(unittest.TestCase):
                                                                                    'AMI']},
                                                    'InstanceType': 't2.micro',
                                                    'KeyName': 'default',
-                                                   'SecurityGroups': [{'Ref': 'BaseHostSG'}],
+                                                   'SecurityGroups': [{'Ref':'BaseHostSG'},{'Ref':'AnotherSG'}],
                                                    'UserData': {'Fn::Base64': {'Fn::Join': ['',
                                                                                                ['#!/bin/bash -xe\n',
                                                                                                 '#do nothing for now']]}}},
@@ -445,6 +446,13 @@ class TestConfigParser(unittest.TestCase):
                                                                     'FromPort': 80,
                                                                     'IpProtocol': 'tcp',
                                                                     'ToPort': 80}],
+                                         'VpcId': {'Ref': 'VPC'}},
+                         'Type': 'AWS::EC2::SecurityGroup'},
+         'AnotherSG': {'Properties': {'GroupDescription': 'BaseHost Security Group',
+                                         'SecurityGroupIngress': [{ 'SourceSecurityGroupName': {'Ref':'BaseHostSG'},
+                                                                    'FromPort': 443,
+                                                                    'IpProtocol': 'tcp',
+                                                                    'ToPort': 443}],
                                          'VpcId': {'Ref': 'VPC'}},
                          'Type': 'AWS::EC2::SecurityGroup'},
          'ScalingGroup': {'Properties': {'AvailabilityZones': {'Fn::GetAZs': ''},
@@ -471,7 +479,7 @@ class TestConfigParser(unittest.TestCase):
             ProjectConfig(
                 'tests/sample-project.yaml',
                 'dev').config, 'my-stack-name')
-        self.assertEquals(known, config.ec2())
+        compare(known, config.ec2())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This changes the security groups section of the yaml file into a dict.
This means you can create multiple SGs with multiple rules and they can reference each other.
