### PR TITLE
Refactor fab_tasks file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  * Move bootstrap script execution to fabric tasks.
  * Fix bug in wait_for_ssh when no instances are running.
  * Add conditional statement in fabfile to check for ssl cert on roll back before trying to delete it.
+ * Refactor fab_tasks get_config method to not return *every* config item. Also PEP8 fixes and removing unused functions.
 
 ## Version 0.1
 

--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -161,20 +161,6 @@ def cfn_create():
         if 'ssl' in cfn_config.data:
             iam.delete_ssl_certificate(cfn_config.ssl(), stack_name)
 
-def get_stack_instances_ips(stack_name):
-    cfn = get_connection(Cloudformation)
-    ec2 = get_connection(EC2)
-    instance_id_list = cfn.get_stack_instance_ids(stack_name)
-    return ec2.get_instance_public_ips(instance_id_list)
-
-
-@task
-def get_stack_addresses():
-    stack_name = get_stack_name()
-    res = get_stack_instances_ips(stack_name)
-    print res
-    return res
-
 
 @task
 def find_master():
@@ -183,12 +169,6 @@ def find_master():
     master = ec2.get_master_instance(stack_name).ip_address
     print 'Salt master public address: {0}'.format(master)
     return master
-
-
-def get_stack_instances_ips(stack_name):
-    stack_name = get_stack_name()
-    ec2 = get_connection(EC2)
-    instance_id_list = cfn.get_stack_instance_ids(stack_name)
 
 
 def get_candidate_minions():


### PR DESCRIPTION
This was movitated by `get_config` having multiple return values and both @mattmb and I wanting to add a new (different) value - 5 is too certainly too many.

Main changes are:
- `get_config()` now returns just a ConfigParser instance
- `get_connection` helper function added to get Cloudformation, EC2, IAM etc connection objects
- PEP8 fixes.
- Removed the unused task `get_stack_addresses` (it was unused cos it didn't do what it said - it returned IDs, not IPs)
