### PR TITLE
Enable cert updates

### DIFF
--- a/bootstrap_cfn/cloudformation.py
+++ b/bootstrap_cfn/cloudformation.py
@@ -47,3 +47,23 @@ class Cloudformation:
 
     def wait_for_stack_missing(self, stack_id, timeout=3600, interval=30):
         return utils.timeout(timeout, interval)(self.stack_missing)(stack_id)
+
+    def get_stack_load_balancers(self, stack_name_or_id):
+        """
+        Collect up the load balancer set of stack resources
+
+        Args:
+            stack_name_or_id (string): Name or id used to identify the stack
+
+        Returns:
+            load_balancers: Set of stack resources containing only
+                load balancers for this stack
+        """
+        # get the stack
+        load_balancers = []
+        stack = self.conn_cfn.describe_stacks(stack_name_or_id)
+        if stack:
+            fn = lambda x: x.resource_type == 'AWS::ElasticLoadBalancing::LoadBalancer'
+            # get the load balancers group
+            load_balancers = filter(fn, stack[0].list_resources())
+        return load_balancers

--- a/bootstrap_cfn/elb.py
+++ b/bootstrap_cfn/elb.py
@@ -1,0 +1,87 @@
+import sys
+import logging
+import boto.ec2.elb
+from bootstrap_cfn import cloudformation
+from bootstrap_cfn import iam
+from bootstrap_cfn import utils
+from bootstrap_cfn.errors import CloudResourceNotFoundError
+
+
+class ELB:
+
+    cfn = None
+    iam = None
+    aws_region_name = None
+    aws_profile_name = None
+
+    def __init__(self, aws_profile_name, aws_region_name='eu-west-1'):
+        self.aws_profile_name = aws_profile_name
+        self.aws_region_name = aws_region_name
+
+        self.conn_elb = utils.connect_to_aws(boto.ec2.elb, self)
+
+        self.iam = iam.IAM(aws_profile_name, aws_region_name)
+        self.cfn = cloudformation.Cloudformation(
+            aws_profile_name, aws_region_name
+        )
+
+    def set_ssl_certificates(self, ssl_config, stack_name):
+        """
+        Look for SSL listeners on all the load balancers connected to
+        this stack, then set update the certificate to that of the config
+
+        Args:
+            ssl_config (dictionary): Certification names to corresponding data
+            stack_name (string): Name of the stack
+
+        Returns:
+            list: The list of load balancers that were affected by the change
+
+        Raises:
+            CloudResourceNotFoundError: Raised when the load balancer key in the cloud
+                config is not found
+        """
+        updated_load_balancers = []
+        for cert_name in ssl_config.keys():
+            # Get the cert id and also its arn
+            cert_id = "{0}-{1}".format(cert_name, stack_name)
+            cert_arn = self.iam.get_arn_for_cert(cert_id)
+
+            # Get all stack load balancers
+            load_balancer_resources = self.cfn.get_stack_load_balancers(stack_name)
+            found_load_balancer_names = [lb.physical_resource_id for lb in load_balancer_resources]
+            # Use load balancer names to filter getting load balancer details
+            load_balancers = []
+            if len(found_load_balancer_names) > 0:
+                load_balancers = self.conn_elb.get_all_load_balancers(load_balancer_names=found_load_balancer_names)
+
+            # Look for https listeners on load balancers and update the cert
+            # using the arn
+            if len(load_balancers) > 0:
+                for load_balancer in load_balancers:
+                    for listener in load_balancer.listeners:
+                        # Get protocol, if https, update cert
+                        # in_port = listener[0]
+                        out_port = listener[1]
+                        protocol = listener[2]
+                        # If the protocol is HTTPS then set the cert on the listener
+                        if protocol == "HTTPS":
+                            logging.info("ELB::set_ssl_certificates: "
+                                         "Found HTTPS protocol on '%s', "
+                                         "updating SSL certificate with '%s'" 
+                                         % (load_balancer.name, cert_arn))
+                            self.conn_elb.set_lb_listener_SSL_certificate(load_balancer.name,
+                                                                          out_port,
+                                                                          cert_arn
+                                                                          )
+                            updated_load_balancers.append(load_balancer)
+
+            else:
+                # Throw key error. There being no load balancers to update is not
+                # necessarily a problem but since the caller expected there to be let
+                # it handle this situation
+                raise CloudResourceNotFoundError("ELB::set_ssl_certificates: "
+                                                 "No load balancers found in stack,")
+
+        return updated_load_balancers
+

--- a/bootstrap_cfn/errors.py
+++ b/bootstrap_cfn/errors.py
@@ -22,3 +22,6 @@ class ProfileNotFoundError(BootstrapCfnError):
         super(ProfileNotFoundError, self).__init__(
             "'{0}' not found in ~/.aws/credentials".format(profile_name)
         )
+
+class CloudResourceNotFoundError(BootstrapCfnError):
+    pass

--- a/bootstrap_cfn/iam.py
+++ b/bootstrap_cfn/iam.py
@@ -1,8 +1,11 @@
 import boto.iam
+from boto.connection import AWSQueryConnection
 from boto.exception import NoAuthHandlerFound
 from boto.provider import ProfileNotFoundError
-
 from bootstrap_cfn import utils
+import logging
+from bootstrap_cfn.errors import CloudResourceNotFoundError
+
 
 class IAM:
 
@@ -18,18 +21,333 @@ class IAM:
 
     def upload_ssl_certificate(self, ssl_config, stack_name):
         for cert_name, ssl_data in ssl_config.items():
-            cert_body = ssl_data['cert']
-            private_key = ssl_data['key']
-            try:
-                cert_chain = ssl_data['chain']
-            except:
-                cert_chain = None
-            cert_id = "{0}-{1}".format(cert_name, stack_name)
-            self.conn_iam.upload_server_cert(cert_id, cert_body, private_key, cert_chain)
+            self.upload_certificate(cert_name,
+                                    stack_name,
+                                    ssl_data,
+                                    force=True)
         return True
 
     def delete_ssl_certificate(self, ssl_config, stack_name):
-        for cert_name in ssl_config.keys():
-            cert_id = "{0}-{1}".format(cert_name, stack_name)
-            self.conn_iam.delete_server_cert(cert_id)
+        for cert_name, ssl_data in ssl_config.items():
+            self.delete_certificate(cert_name,
+                                    stack_name,
+                                    ssl_data,
+                                    force=True)
         return True
+
+    def update_ssl_certificates(self, ssl_config, stack_name):
+        """
+        Update all the ssl certificates in the identified stack. Raise an 
+        exception if we try to update a non-existent certificate
+
+        Args:
+            ssl_config(dictionary): A dictionary of ssl configuration data organised by
+                cert_name to a dictionary with the config data in it
+            stack_name(string): The name of the stack
+
+        Returns:
+            list: List of certificates that were successfully updated
+        """
+        updated_certificates = []
+        for cert_name, ssl_data in ssl_config.items():
+            try:
+                    delete_success = self.delete_certificate(cert_name,
+                                                             stack_name,
+                                                             ssl_data)
+                    if delete_success:
+                        upload_success = self.upload_certificate(cert_name,
+                                                                 stack_name,
+                                                                 ssl_data,
+                                                                 force=True)
+                        if upload_success:
+                            updated_certificates.append(cert_name)
+                            logging.info("IAM::update_ssl_certificates: "
+                                         "Updated certificate '%s': "
+                                         % (cert_name))
+                        else:
+                            logging.warn("IAM::update_ssl_certificates: "
+                                         "Failed to update certificate '%s': "
+                                         % (cert_name))
+                    else:
+                        msg = ("IAM::update_ssl_certificates: "
+                               "Could not update certificate '%s': "
+                               "Certificate does not exist remotely" 
+                               % (cert_name))
+                        raise CloudResourceNotFoundError(msg)
+
+            except AWSQueryConnection.ResponseError as error:
+                logging.warn("IAM::update_ssl_certificates: "
+                             "Could not update certificate '%s': "
+                             "Error %s - %s" % (cert_name,
+                                                error.status,
+                                                error.reason))
+        return updated_certificates
+
+    def get_remote_certificate(self, cert_name, stack_name):
+        """
+        Check to see if the remote certificate exists already in AWS
+
+        Args:
+            cert_name(string): The name of the certificate entry to look up
+            stack_name(string): The name of the stack
+            ssl_data(dictionary): The configuration data for this
+                certificate entry
+
+        Returns:
+            exists(bool): True if remote AWS certificate exists, false otherwise
+        """
+
+        try:
+            cert_id = "{0}-{1}".format(cert_name, stack_name)
+            logging.info("IAM::get_remote_certificate: "
+                         "Found certificate '%s'.."
+                         % (cert_id))
+
+            # Fetch the remote AWS certificate configuration data
+            # Fetching the response could throw an exception
+            remote_cert_response = self.conn_iam.get_server_certificate(cert_id)
+            remote_cert_result = remote_cert_response['get_server_certificate_response']['get_server_certificate_result']
+            remote_cert_certificate = remote_cert_result["server_certificate"]
+
+            remote_cert_data = {
+                "cert": remote_cert_certificate.get("certificate_body",
+                                                    None),
+                "chain": remote_cert_certificate.get("certificate_chain",
+                                                     None),
+                "key": remote_cert_certificate.get("certificate_key",
+                                                   None),
+            }
+            return remote_cert_data
+        # Handle any problems connecting to the remote AWS 
+        except AWSQueryConnection.ResponseError as error:
+                    logging.info("IAM::get_remote_certificate: "
+                                 "Could not find certificate '%s': "
+                                 "Error %s - %s" % (cert_id,
+                                                    error.status,
+                                                    error.reason))
+                    return None
+
+    def compare_remote_certificate_data(self, cert_name, stack_name, ssl_data):
+        """
+        Check to see if the remote certificate exists already in AWS
+
+        Args:
+            cert_name(string): The name of the certificate entry to look up
+            stack_name(string): The name of the stack
+            ssl_data(dictionary): The configuration data for this
+                certificate entry
+
+        Returns:
+            exists(bool): True if remote AWS certificate exists, false otherwise
+        """
+
+        try:
+            cert_id = "{0}-{1}".format(cert_name, stack_name)
+            logging.info("IAM::get_remote_certificate: "
+                         "Found certificate '%s'.."
+                         % (cert_id))
+
+            # Fetch the remote AWS certificate configuration data
+            # Fetching the response could throw an exception
+            remote_cert_response = self.conn_iam.get_server_certificate(cert_id)
+            remote_cert_result = remote_cert_response['get_server_certificate_response']['get_server_certificate_result']
+            remote_cert_certificate = remote_cert_result["server_certificate"]
+
+            remote_cert_data = {
+                "cert": remote_cert_certificate.get("certificate_body",
+                                                    None),
+                "chain": remote_cert_certificate.get("certificate_chain",
+                                                     None),
+                "key": remote_cert_certificate.get("certificate_key",
+                                                   None),
+            }
+            # Compare the local cert and chain certificates to remote
+            if self.compare_certificate_data(ssl_data, remote_cert_data):
+                logging.info("IAM::get_remote_certificate: "
+                             "Local and remote certificates are equal, "
+                             "certificate id '%s' "
+                             % (cert_name))
+                return True
+            else:
+                logging.info("IAM::get_remote_certificate: "
+                             "Local and remote certificates are not the same, "
+                             "certificate id '%s' "
+                             % (cert_id))
+                return False
+        # Handle any problems connecting to the remote AWS 
+        except AWSQueryConnection.ResponseError as error:
+                    logging.info("IAM::get_remote_certificate: "
+                                 "Could not find certificate '%s': "
+                                 "Error %s - %s" % (cert_id,
+                                                    error.status,
+                                                    error.reason))
+                    return False
+
+        return False
+
+    def compare_certificate_data(self, cert_data1, cert_data2):
+        """
+        Compare two sets of certificate data for equality
+
+        Args:
+            cert1(dictionary): Dictionary of certificate data,
+                with certs, chains and keys
+            cert2(dictionary): Dictionary of certificate data,
+                with certs, chains and keys
+
+        Returns:
+            are_equal: True if the certficate data are equal,
+            false otherwise
+        """
+
+        are_equal = False
+        certs_are_equal = self.compare_certs_body(
+                                                  cert_data1.get("cert", None),
+                                                  cert_data2.get("cert", None))
+        if not certs_are_equal:
+            logging.info("IAM::compare_certificate_data: "
+                         "Certificate body data is not equal")
+        else:
+            chains_are_equal = self.compare_certs_body(cert_data1.get("chain", None),
+                                                       cert_data2.get("chain", None))
+            if not chains_are_equal:
+                logging.info("IAM::compare_certificate_data: "
+                             "Certificate chain data is not equal")
+            else:
+                are_equal = True
+
+        return are_equal
+
+    def compare_certs_body(self,
+                           text1,
+                           text2):
+        start_text = "-----BEGIN CERTIFICATE-----"
+        end_text = "-----END CERTIFICATE-----"
+        are_equal = False
+        if (text1 and text2 and (len(text1) > 0) and (len(text2) > 0)):
+            # Get the actual key data
+            body1 = (text1.split(start_text))[1].split(end_text)[0]
+            body2 = (text2.split(start_text))[1].split(end_text)[0]
+            if body1 and body2:
+                are_equal = (body1 == body2)
+
+        return are_equal
+
+    def upload_certificate(self, cert_name, stack_name, ssl_data, force=False):
+        """
+        Upload a certificate
+
+        Args:
+            cert_name(string): The name of the certificate entry to look up
+            stack_name(string): The name of the stack
+            ssl_data(dictionary): The configuration data for this certificate
+                entry
+            force(bool): True to upload even if certificate exists, false
+                to not overwrite existing certificates
+
+        Returns:
+            success(bool): True if certificate is uploaded, False otherwise
+        """
+        cert_body = ssl_data['cert']
+        private_key = ssl_data['key']
+        try:
+            cert_chain = ssl_data['chain']
+        except KeyError:
+            cert_chain = None
+
+        cert_id = "{0}-{1}".format(cert_name, stack_name)
+
+        try:
+            if force or not self.get_remote_certificate(cert_name,
+                                                                 stack_name,
+                                                                 ssl_data):
+                self.conn_iam.upload_server_cert(cert_id, cert_body,
+                                                 private_key,
+                                                 cert_chain)
+                logging.info("IAM::upload_certificate: "
+                             "Uploading certificate '%s'.."
+                             % (cert_name))
+                return True
+            else:
+                logging.info("IAM::upload_certificate: "
+                             "Certificate '%s' already exists "
+                             "and not forced so skipping upload."
+                             % (cert_name))
+                return False
+        except AWSQueryConnection.ResponseError as error:
+            logging.warn("IAM::upload_certificate: "
+                         "Problem uploading certificate '%s': "
+                         "Error %s - %s" % (cert_name,
+                                            error.status,
+                                            error.reason))
+            return False
+
+        return False
+
+    def delete_certificate(self, cert_name, stack_name, ssl_data):
+        """
+        Delete a certificate from AWS
+
+        Args:
+                cert_name(string): The name of the certificate entry to look up
+                stack_name(string): The name of the stack
+                ssl_data(dictionary): The configuration data for this
+                    certificate entry
+
+        Returns:
+            success(bool): True if a certificate is deleted, False otherwise
+        """
+        cert_id = "{0}-{1}".format(cert_name, stack_name)
+        # Try to delete cert, but handle any problems on
+        # individual deletes and
+        # continue to delete other certs
+        try:
+            if self.get_remote_certificate(cert_name,
+                                           stack_name,
+                                           ssl_data):
+                self.conn_iam.delete_server_cert(cert_id)
+                logging.info("IAM::delete_certificate: "
+                             "Deleting certificate '%s'.."
+                             % (cert_name))
+                return True
+            else:
+                logging.info("IAM::delete_certificate: "
+                             "Certificate '%s' does not exist, "
+                             "not deleting." % (cert_name))
+                return False
+        except AWSQueryConnection.ResponseError as error:
+            logging.warn("IAM::delete_certificate: "
+                         "Could not find expected certificate '%s': "
+                         "Error %s - %s" % (cert_id,
+                                            error.status,
+                                            error.reason))
+            return False
+
+        return False
+
+    def get_arn_for_cert(self, cert_name):
+        """
+        Use a certificates name to find the arn
+
+        Args:
+            cert_name (string): The name of the certification
+
+        Returns:
+            cert_arn (string): The certifications arn if found,
+                None type otherwise
+        """
+        cert_arn = None
+
+        try:
+            cert = self.conn_iam.get_server_certificate(cert_name)
+            cert_arn = cert.arn
+            logging.info("IAM::get_arn_for_cert: "
+                         "Found arn '%s' for certificate '%s'"
+                         % (cert_arn, cert_name))
+        except:
+            cert_arn = None
+            logging.warn("IAM::get_arn_for_cert: "
+                         "Could not find arn for certificate '%s'"
+                         % (cert_name))
+
+        return cert_arn

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -1,0 +1,294 @@
+import bootstrap_cfn
+from bootstrap_cfn import iam
+import unittest
+from nose.tools import raises
+import boto
+from mock import Mock
+from mock import patch
+from bootstrap_cfn.errors import CloudResourceNotFoundError
+
+
+class TestIAM(unittest.TestCase):
+
+    # The IAM mock object to use
+    mock_iam = None
+
+    # Dictionary of test local cert data to use
+    test_certs = \
+        {
+            "test_cert_1":
+                {
+                    "cert": ("-----BEGIN CERTIFICATE-----"
+                             "CERT1CERT1CERT1CERT1CERT1CER"
+                             "-----END CERTIFICATE-----"),
+                    "chain": ("-----BEGIN CERTIFICATE-----"
+                              "CHAIN1CHAIN1CHAIN1CHAIN1CHA"
+                              "-----END CERTIFICATE-----"),
+                    "key": ("-----BEGIN PRIVATE KEY-----"
+                            "KEY1KEY1KEY1KEY1KEY1KEY1KEY"
+                            "-----END PRIVATE KEY-----")
+                },
+            "test_cert_2":
+                {
+                    "cert": ("-----BEGIN CERTIFICATE-----"
+                             "CERT2CERT2CERT2CERT2CERT2CER"
+                             "-----END CERTIFICATE-----"),
+                    "chain": ("-----BEGIN CERTIFICATE-----"
+                              "CHAIN2CHAIN2CHAIN2CHAIN2CHA"
+                              "-----END CERTIFICATE-----"),
+                    "key": ("-----BEGIN PRIVATE KEY-----"
+                            "KEY2KEY2KEY2KEY2KEY2KEY2KEY"
+                            "-----END PRIVATE KEY-----")
+                }
+        }
+
+    # Dictionary of test remote certificates to use
+    remote_test_certs = \
+        {
+            "test_cert_1":
+                {
+                    "certificate_body": ("-----BEGIN CERTIFICATE-----"
+                                         "CERT1CERT1CERT1CERT1CERT1CER"
+                                         "-----END CERTIFICATE-----"),
+                    "certificate_chain": ("-----BEGIN CERTIFICATE-----"
+                                          "CHAIN1CHAIN1CHAIN1CHAIN1CHA"
+                                          "-----END CERTIFICATE-----"),
+                    "certificate_key": ("-----BEGIN PRIVATE KEY-----"
+                                        "KEY1KEY1KEY1KEY1KEY1KEY1KEY"
+                                        "-----END PRIVATE KEY-----")
+                },
+            "test_cert_3":
+                {
+                    "certificate_body": ("-----BEGIN CERTIFICATE-----"
+                                         "CERT2CERT2CERT2CERT2CERT2CER"
+                                         "-----END CERTIFICATE-----"),
+                    "certificate_chain": ("-----BEGIN CERTIFICATE-----"
+                                          "CHAIN2CHAIN2CHAIN2CHAIN2CHA"
+                                          "-----END CERTIFICATE-----"),
+                    "certificate_key": ("-----BEGIN PRIVATE KEY-----"
+                                        "KEY2KEY2KEY2KEY2KEY2KEY2KEY"
+                                        "-----END PRIVATE KEY-----")
+                }
+        }
+
+    cert1_remote_get_certificate_response = \
+    {
+        "get_server_certificate_response":
+            {
+             "get_server_certificate_result": 
+                {
+                    "server_certificate": {
+                                           "certificate_body": ("-----BEGIN CERTIFICATE-----"
+                                                                "CERT1CERT1CERT1CERT1CERT1CER"
+                                                                "-----END CERTIFICATE-----"),
+                                           "certificate_chain": ("-----BEGIN CERTIFICATE-----"
+                                                                 "CHAIN1CHAIN1CHAIN1CHAIN1CHA"
+                                                                 "-----END CERTIFICATE-----"),
+                                           "certificate_key": ("-----BEGIN PRIVATE KEY-----"
+                                                               "KEY1KEY1KEY1KEY1KEY1KEY1KEY"
+                                                               "-----END PRIVATE KEY-----")
+                                           }
+                 }
+             }
+    }
+    successful_response = \
+        {
+            "status": 200,
+            "reason": "success",
+            "body": ""
+        }
+    unsuccessful_response = \
+        {
+            "status": 404,
+            "reason": "unsuccessful",
+            "body": ""
+        }
+
+    def setUp(self):
+        iam_mock = Mock()
+        iam_connect_result = Mock(name='iam_connect')
+        iam_mock.return_value = iam_connect_result
+        boto.iam.connect_to_region = iam_mock
+        self.mock_iam = iam.IAM('mock_profile')
+
+    @patch("boto.iam.IAMConnection.upload_server_cert")
+    @patch("bootstrap_cfn.iam.IAM.get_remote_certificate")
+    def test_update_ssl_certificates(self,
+                                     mock_get_remote_certificate,
+                                     mock_upload_server_cert):
+        """
+        Test we update certificates when forced
+        """
+        mock_get_remote_certificate.side_effect = [self.remote_test_certs['test_cert_1'],
+                                                   self.remote_test_certs['test_cert_3'],
+                                                   None]
+        mock_upload_server_cert.side_effect = [self.successful_response,
+                                               self.successful_response]
+        ssl_config = self.test_certs
+        stack_name = "test_stack"
+
+        update_list = self.mock_iam.update_ssl_certificates(ssl_config,
+                                                             stack_name)
+        self.assertEqual(len(update_list),
+                         2,
+                         "TestIAM::test_update_ssl_certificates_force: "
+                         "Should be able update certs"
+                         )
+
+    @raises(CloudResourceNotFoundError)
+    @patch("boto.iam.IAMConnection.delete_server_cert")
+    @patch("boto.iam.IAMConnection.upload_server_cert")
+    @patch("bootstrap_cfn.iam.IAM.get_remote_certificate")
+    def test_update_ssl_certificates_not_exist(self,
+                                               mock_get_remote_certificate,
+                                               mock_upload_server_cert,
+                                               mock_delete_server_cert):
+        """
+        Test we cause an exception trying update over
+        non existing certificates
+        """
+        mock_get_remote_certificate.side_effect = [True,
+                                                            False,
+                                                            False,
+                                                            None]
+        mock_upload_server_cert.side_effect = [self.successful_response,
+                                               self.unsuccessful_response,
+                                               None]
+        mock_delete_server_cert.side_effect = [self.successful_response,
+                                               self.unsuccessful_response,
+                                               None]
+        ssl_config = self.test_certs
+        stack_name = "test_stack"
+        update_count = self.mock_iam.update_ssl_certificates(ssl_config,
+                                                             stack_name)
+        self.assertEqual(update_count,
+                         1,
+                         "TestIAM::test_update_ssl_certificates_force: "
+                         "Should only be able to update existing certificates "
+                         )
+
+    @patch("boto.iam.IAMConnection.upload_server_cert")
+    @patch("bootstrap_cfn.iam.IAM.get_remote_certificate")
+    def test_upload_certificate_not_exists(self,
+                                mock_get_remote_certificate,
+                                mock_upload_server_cert):
+        """
+        Test that we can upload a certificate if it doesnt exist remotely
+        """
+        mock_get_remote_certificate.return_value = False
+        mock_upload_server_cert.return_value = self.successful_response
+        cert_name = "cert1"
+        stack_name = "test_stack"
+        ssl_data = self.test_certs["test_cert_1"]
+        force = False
+        success = self.mock_iam.upload_certificate(cert_name, stack_name, ssl_data, force)
+        self.assertTrue(success,
+                        "TestIAM::test_upload_certificate_exists: "
+                        "Should be able to upload a non existent cert "
+                        )
+
+    @patch("boto.iam.IAMConnection.upload_server_cert")
+    @patch("bootstrap_cfn.iam.IAM.get_remote_certificate")
+    def test_upload_certificate_exists(self,
+                                mock_get_remote_certificate,
+                                mock_upload_server_cert):
+        """
+        Test that we cannot upload a certificate if it exists remotely
+        """
+        mock_get_remote_certificate.return_value = True
+        mock_upload_server_cert.return_value = self.unsuccessful_response
+        cert_name = "cert1"
+        stack_name = "test_stack"
+        ssl_data = self.test_certs["test_cert_1"]
+        force = False
+        success = self.mock_iam.upload_certificate(cert_name, stack_name, ssl_data, force)
+        self.assertFalse(success,
+                        "TestIAM::test_upload_certificate_exists: "
+                        "Should not be able to upload an existent cert "
+                        )
+        
+    @patch("boto.iam.IAMConnection.delete_server_cert")
+    @patch("bootstrap_cfn.iam.IAM.get_remote_certificate")
+    def test_delete_certificate_exists(self,
+                                       mock_get_remote_certificate,
+                                       mock_delete_server_cert):
+        """
+        Test that we can delete a certificate if it exists
+        """
+        mock_get_remote_certificate.return_value = True
+        mock_delete_server_cert.return_value = self.successful_response
+        cert_name = "cert1"
+        stack_name = "test_stack"
+        ssl_data = self.test_certs["test_cert_1"]
+
+        success = self.mock_iam.delete_certificate(cert_name, stack_name, ssl_data)
+        self.assertTrue(success,
+                         "TestIAM::test_delete_certificate_exists: "
+                         "Should only be able to delete an existent cert "
+                         )
+
+    @patch("boto.iam.IAMConnection.delete_server_cert")
+    @patch("bootstrap_cfn.iam.IAM.get_remote_certificate")
+    def test_delete_certificate_not_exists(self,
+                                           mock_get_remote_certificate,
+                                           mock_delete_server_cert):
+        """
+        Test we get false on trying to delete a non-existent certificate
+        """
+        mock_get_remote_certificate.return_value = None
+        mock_delete_server_cert.return_value = self.unsuccessful_response
+        cert_name = "cert1"
+        stack_name = "test_stack"
+        ssl_data = self.test_certs["test_cert_1"]
+
+        success = self.mock_iam.delete_certificate(cert_name, stack_name, ssl_data)
+        self.assertFalse(success,
+                         "TestIAM::test_delete_certificate_not_exists: "
+                         "Should not be able to delete "
+                         "a non-existant cert")
+
+    def test_compare_certificates_equal(self):
+        local_cert_data = self.test_certs["test_cert_1"]
+        remote_cert = self.remote_test_certs["test_cert_1"]
+        remote_cert_data = \
+        {
+         "cert": remote_cert["certificate_body"],
+         "chain": remote_cert["certificate_chain"],
+         "key": remote_cert["certificate_key"],
+         }
+        certs_equal = self.mock_iam.compare_certificate_data(local_cert_data, 
+                                                             remote_cert_data)
+
+        self.assertTrue(certs_equal, 
+                        "Local and remote certificates should be equal")
+
+    def test_compare_certificates_unequal(self):
+        local_cert_data = self.test_certs["test_cert_1"]
+        remote_cert1 = self.remote_test_certs["test_cert_1"]
+        remote_cert2 = self.remote_test_certs["test_cert_3"]
+
+        # Test when cert is different
+        remote_cert_data = \
+        {
+         "cert": remote_cert2["certificate_body"],
+         "chain": remote_cert1["certificate_chain"],
+         }
+        certs_equal = self.mock_iam.compare_certificate_data(local_cert_data,
+                                                             remote_cert_data)
+
+        self.assertFalse(certs_equal,
+                         "Local and remote certificates should not be equal"
+                         )
+
+        # Test when chain is different
+        remote_cert_data = \
+        {
+         "cert": remote_cert1["certificate_body"],
+         "chain": remote_cert2["certificate_chain"],
+         }
+        certs_equal = self.mock_iam.compare_certificate_data(local_cert_data,
+                                                             remote_cert_data)
+
+        self.assertFalse(certs_equal,
+                         "Local and remote certificates should not be equal"
+                         )


### PR DESCRIPTION
When we change the certificate in our cloud formation config we want a way to update the certificates on instances, and to set these certificates on any https load balancers on the stack. 
This patch creates a fab_task update_certs() to carry out both of these tasks, first removing/adding the certificates using IAM, then using a simple ELB class to set_ssl_certificates() on any https listeners on the stacks load_balancers
