### PR TITLE
Making block_devices non mandatory in EC2 block definition.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ This tool needs AWS credentials to create stacks and the credentials should be p
 
 Project specific YAML file
 +++++++++++++++++++++++++++
-The YAML file below highlights what is possible with all the bootstrap-cfn features available to date. The minimum requirement is that it must contain an *ec2* block, you **do not** have to use RDS, S3 or ELB's.
+The YAML file below highlights what is possible with all the bootstrap-cfn features available to date. The minimum requirement is that it must contain an *ec2* block, you **do not** have to use RDS, S3 or ELB's. Block devices in EC2 block is non mandatory as well. If no block devices specified, default root device with 20GB space will be created.
 
 ::
 
@@ -95,7 +95,7 @@ The YAML file below highlights what is possible with all the bootstrap-cfn featu
           InstanceType: t2.micro
         block_devices:
           - DeviceName: /dev/sda1
-            VolumeSize: 10
+            VolumeSize: 20
           - DeviceName: /dev/sdf
             VolumeSize: 10
         security_groups:
@@ -173,9 +173,9 @@ Salt specific configuration
 
 In order to rsync your salt states to the salt master you need to add a `salt` section to the top level of your project's YAML file. The following parameters specify the rsync sources and targets:
 
-- **local_salt_dir**: Directory containing all the files you want to have in your salt root (for example top.sls or project specific states). 
+- **local_salt_dir**: Directory containing all the files you want to have in your salt root (for example top.sls or project specific states).
     **Default value**: ./salt
-- **local_pillar_dir**: Directory containing all the files you want to have in your pillar root. 
+- **local_pillar_dir**: Directory containing all the files you want to have in your pillar root.
     **Default value**: ./pillar
 - **local_vendor_dir**: Directory containing formulas cloned by salt-shaker.
     **Default value**: ./vendor

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -262,9 +262,13 @@ class ConfigParser:
 
         # BLOCK DEVICE MAPPING
         devices = []
-        for i in self.data['ec2']['block_devices']:
+        try:
+            for i in self.data['ec2']['block_devices']:
+                devices.append(
+                    {'DeviceName': i['DeviceName'], 'Ebs': {'VolumeSize': i['VolumeSize']}})
+        except KeyError:
             devices.append(
-                {'DeviceName': i['DeviceName'], 'Ebs': {'VolumeSize': i['VolumeSize']}})
+                {'DeviceName': '/dev/sda1', 'Ebs': {'VolumeSize': 20 }})
         template['BaseHostLaunchConfig']['Properties'][
             'BlockDeviceMappings'] = devices
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -545,10 +545,11 @@ class TestConfigParser(unittest.TestCase):
     def test_ec2_with_no_block_device_specified(self):
         from testfixtures import compare
         project_config = ProjectConfig('tests/sample-project.yaml', 'dev')
-        project_config.config.pop('rds')
         project_config.config['ec2'].pop('block_devices')
         config = ConfigParser(project_config.config, 'my-stack-name')
-        config.process()
+        config_output = config.ec2()['BaseHostLaunchConfig']['Properties']['BlockDeviceMappings']
+        known = [{'DeviceName': '/dev/sda1', 'Ebs': {'VolumeSize': 20}}]
+        self.assertEquals(known, config_output)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -542,6 +542,13 @@ class TestConfigParser(unittest.TestCase):
                 'dev').config, 'my-stack-name')
         compare(known, config.ec2())
 
+    def test_ec2_with_no_block_device_specified(self):
+        from testfixtures import compare
+        project_config = ProjectConfig('tests/sample-project.yaml', 'dev')
+        project_config.config.pop('rds')
+        project_config.config['ec2'].pop('block_devices')
+        config = ConfigParser(project_config.config, 'my-stack-name')
+        config.process()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This fixes #3
