### PR TITLE
Fix/custom s3 policy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,3 +109,14 @@ By default the ELBs will have a security group opening them to the world on 80 a
 If you set the protocol on an ELB to HTTPS you must include a key called `certificate_name` in the ELB block (as example above) and matching cert data in a key with the same name as the cert under `ssl` (see example above). The `cert` and `key` are required and the `chain` is optional.
 
 The certificate will be uploaded before the stack is created and removed after it is deleted.
+
+Applying a custom s3 policy
+++++++++++++++++++++++++++++
+You can add a custom s3 policy to override bootstrap-cfn's default settings. For example, the sample custom policy defined in this `json file <https://github.com/ministryofjustice/bootstrap-cfn/blob/master/tests/sample-custom-s3-policy.json>`_ can be configured as follows:
+
+::
+
+   s3:
+     static-bucket-name: moj-test-dev-static
+     policy: tests/sample-custom-s3-policy.json
+

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -121,7 +121,7 @@ class ConfigParser:
 
         #policy = None
         if 'policy' in present_keys:
-            policy = json.loads(open(self.data['policy']).read())
+            policy = json.loads(open(self.data['s3']['policy']).read())
         else:
              arn = 'arn:aws:s3:::%s/*' % self.data['s3']['static-bucket-name']
              policy = {'Action': ['s3:Get*', 's3:Put*', 's3:List*'], 'Resource': arn, 'Effect': 'Allow', 'Principal' : {'AWS' : '*'}}

--- a/tests/sample-custom-s3-policy.json
+++ b/tests/sample-custom-s3-policy.json
@@ -1,0 +1,5 @@
+{   "Action": ["s3:Get*", "s3:Put*", "s3:List*", "s3:Delete*"],
+    "Resource": "arn:aws:s3:::moj-test-dev-static/*",
+    "Effect": "Allow",
+    "Principal": { "AWS": "*" }
+}


### PR DESCRIPTION
This bugfix ensures you can apply a custom s3 policy to the cloudformation yaml config.

Connects to #54
