### PR TITLE
Enforce PEP8 on any changed hunks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,26 @@
 language: python
 
 install:
-  - pip install coveralls
+  - pip install coveralls flake8
 
 python:
   - "2.7"
 
 # command to install dependencies and run tests
-script: 
-  coverage run --source=bootstrap_cfn setup.py test
+script:
+  # If we are a Pull request, check the changes introduced in it for pep8
+  #
+  # Or if we are just on a branch, work out what we've changed since we
+  # branched off master
+  - |
+    set -e -o pipefail;
+    if [ "$TRAVIS_PULL_REQUEST" != "false" ]
+      then git diff $TRAVIS_COMMIT_RANGE | flake8 --diff;
+      else git fetch -q origin master:origin/master && git diff origin/master... | flake8 --diff
+    fi
+
+  # Then run the tests
+  - coverage run --source=bootstrap_cfn setup.py test
 
 after_success:
   coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length=160


### PR DESCRIPTION
An enforcable stlye guide is a good thing - we have some developers who are
less experienced with python so being able to say 'do it this way' is a
good thing.

I am open to disabling some more rules (for instance I have set line
lengths to 160 up from the default 79) but not the enforcement of a style.

This change means that we don't have to fix PEP8 style violations in one
big go, and can still get useful automated style checking.
