### PR TITLE
 Add RDS storage encryption:

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,3 +108,15 @@ If you wish to include some static cloudformation json and have it merged with t
       - /path/to/cloudformation.json
 
 The tool will then perform a deep merge of the includes with the generated template dictionary. Any keys or subkeys in the template dictionary that clash will have their values **overwritten** by the included dictionary or recursively merged if the value is itself a dictionary.
+
+
+Enabling RDS encryption
++++++++++++++++++++++++++
+You can enable encryption for your DB by adding the following::
+ 
+  rds:
+     storage-encrypted: true
+     instance-class: db.m3.medium
+
+**NOTE:** AWS does not support RDS encryption for the *db.t2.** instance classes. More details on supported instance classes are available `here <http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Encryption.html>`_
+

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -159,6 +159,10 @@ class ConfigParser:
             'multi-az': 'MultiAZ'
         }
 
+        optional_fields = {
+            'storage-encrypted': 'StorageEncrypted',
+        }
+
         # LOAD STACK TEMPLATE
         template = json.loads(
             pkgutil.get_data(
@@ -173,6 +177,11 @@ class ConfigParser:
             else:
                 template['RDSInstance']['Properties'][
                     required_fields[i]] = self.data['rds'][i]
+
+        for i in optional_fields.keys():
+            if i in self.data['rds'].keys():
+                template['RDSInstance']['Properties'][
+                    optional_fields[i]] = self.data['rds'][i]
 
         return template
 

--- a/bootstrap_cfn/stacks/rds.json
+++ b/bootstrap_cfn/stacks/rds.json
@@ -37,6 +37,7 @@
       "MasterUsername": "",
       "MasterUserPassword": "",
       "AllocatedStorage": "",
+      "StorageEncrypted": false,
       "StorageType": "",
       "Engine": "",
       "EngineVersion": "",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -41,7 +41,7 @@ class TestConfig(unittest.TestCase):
 class TestConfigParser(unittest.TestCase):
 
     def setUp(self):
-        self.maxDiff = 3000
+        self.maxDiff = 9000
 
     def test_iam(self):
         known = {'RolePolicies': {'Type': 'AWS::IAM::Policy',
@@ -179,6 +179,7 @@ class TestConfigParser(unittest.TestCase):
                     'MasterUsername': 'testuser',
                     'MultiAZ': False,
                     'PubliclyAccessible': False,
+                    'StorageEncrypted': False,
                     'StorageType': 'gp2'
                 }
             },


### PR DESCRIPTION
AWS Cloudformation API now supports RDS storage encryption. This
change adds StorageEncrypted key to boootstrap_cfn RDS config as
a required field.

Connected to #80
