### PR TITLE
Config for zero downtime deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version unreleased
+
+* Enable connection draining on ELBs
+* Add IAM permissions so an instance can register/deregister itself from ELB.
+* Add custom ELB healthchecks so you can point an ELB at a URL (not just a port)
+
 ## Version 0.4.1
 
 * Fix dist to not include tests/ folder
@@ -9,8 +15,6 @@
 ## Version 0.4.0
 
 First release to PyPi
-
-* Add custom ELB healthchecks so you can point an ELB at a URL (not just a port)
 
 ## Version 0.3.3
 

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -258,7 +258,7 @@ class ConfigParser:
                 'PolicyName'] = safe_name + "BaseHost"
             template['ELBRolePolicies']['Properties'][
                 'PolicyDocument']['Statement'][0][
-                'Resource'][0]['Fn::Join'][-1][-1] = ':loadbalancer/ELB%s' % elb['name'].replace('.', '')
+                'Resource'][0]['Fn::Join'][-1][-1] = ':loadbalancer/ELB-%s' % elb['name'].replace('.', '')
             template['DNSRecord']['Properties'][
                 'HostedZoneName'] = elb['hosted_zone']
             template['DNSRecord']['Properties']['RecordSets'][0][

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -254,6 +254,11 @@ class ConfigParser:
                 'LoadBalancerName'] = 'ELB-%s' % elb['name'].replace('.', '')
             template['ElasticLoadBalancer'][
                 'Properties']['Scheme'] = elb['scheme']
+            template['ELBRolePolicies']['Properties'][
+                'PolicyName'] = safe_name + "BaseHost"
+            template['ELBRolePolicies']['Properties'][
+                'PolicyDocument']['Statement'][0][
+                'Resource'][0]['Fn::Join'][-1][-1] = ':loadbalancer/ELB%s' % elb['name'].replace('.', '')
             template['DNSRecord']['Properties'][
                 'HostedZoneName'] = elb['hosted_zone']
             template['DNSRecord']['Properties']['RecordSets'][0][
@@ -276,6 +281,8 @@ class ConfigParser:
                 {'ELB%s' % safe_name: template['ElasticLoadBalancer']})
             elb_list.append(
                 {'DNS%s' % safe_name: template['DNSRecord']})
+            elb_list.append(
+                {'Policy%s' % safe_name: template['ELBRolePolicies']})
 
         return elb_list, elb_sgs
 

--- a/bootstrap_cfn/stacks/elb.json
+++ b/bootstrap_cfn/stacks/elb.json
@@ -10,6 +10,36 @@
             ]
         }
     },
+    "ELBRolePolicies": {
+        "Type": "AWS::IAM::Policy",
+        "Properties": {
+            "PolicyName": "ELBBaseHost",
+            "PolicyDocument": {
+                "Statement": [
+                    { "Action" : [
+                          "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+                          "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
+                      ],
+                      "Resource" : [
+                           {
+                               "Fn::Join": [
+                                   "",
+                                      [
+                                          "arn:aws:elasticloadbalancing:",
+                                          { "Ref" : "AWS::Region" },
+                                          ":",
+                                          { "Ref":"AWS::AccountId" },
+                                          "This is overwritten in config.py"
+                                      ]
+                               ]
+                           }
+                       ],
+                      "Effect": "Allow" }
+                ]
+            },
+            "Roles": [ { "Ref": "BaseHostRole" } ]
+        }
+    },
     "DefaultELBSecurityGroup" : {
        "Type" : "AWS::EC2::SecurityGroup",
        "Properties" :

--- a/bootstrap_cfn/stacks/elb.json
+++ b/bootstrap_cfn/stacks/elb.json
@@ -4,6 +4,10 @@
         "Properties" : {
             "LoadBalancerName": "",
             "Scheme" : "internet-facing",
+            "ConnectionDrainingPolicy": {
+                "Enabled" : true,
+                "Timeout" : 120 
+             },
             "Subnets": [{ "Ref" : "SubnetA" }, { "Ref" : "SubnetB" }, { "Ref" : "SubnetC" }],
             "SecurityGroups": [{ "Ref": "DefaultELBSecurityGroup" }],
             "Listeners" : [

--- a/bootstrap_cfn/stacks/iam.json
+++ b/bootstrap_cfn/stacks/iam.json
@@ -15,6 +15,7 @@
                     { "Action": [ "autoscaling:Describe*" ], "Resource": "*", "Effect": "Allow" },
                     { "Action": [ "ec2:Describe*" ], "Resource": "*", "Effect": "Allow" },
                     { "Action": [ "rds:Describe*" ], "Resource": "*", "Effect": "Allow" },
+                    { "Action": [ "elasticloadbalancing:Describe*" ], "Resource": "*", "Effect": "Allow" },
                     { "Action": [ "elasticache:Describe*" ], "Resource": "*", "Effect": "Allow" },
                     { "Action": [ "cloudformation:Describe*" ], "Resource": "*", "Effect": "Allow" },
                     { "Action": [ "s3:List*" ], "Resource": "*", "Effect": "Allow" }

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -260,7 +260,7 @@ class TestConfigParser(unittest.TestCase):
                                                           {u'Ref': u'AWS::Region'},
                                                           u':',
                                                           {u'Ref': u'AWS::AccountId'},
-                                                          ':loadbalancer/ELBtest-dev-external']]}]}]},
+                                                          ':loadbalancer/ELB-test-dev-external']]}]}]},
                     u'PolicyName': 'testdevexternalBaseHost',
                     u'Roles': [{u'Ref': u'BaseHostRole'}]},
                 u'Type': u'AWS::IAM::Policy'}},
@@ -306,7 +306,7 @@ class TestConfigParser(unittest.TestCase):
                                                       {u'Ref': u'AWS::Region'},
                                                       u':',
                                                       {u'Ref': u'AWS::AccountId'},
-                                                      ':loadbalancer/ELBtest-dev-internal']]}]}]},
+                                                      ':loadbalancer/ELB-test-dev-internal']]}]}]},
                         u'PolicyName': 'testdevinternalBaseHost',
                         u'Roles': [{u'Ref': u'BaseHostRole'}]},
                 u'Type': u'AWS::IAM::Policy'}}
@@ -532,7 +532,7 @@ class TestConfigParser(unittest.TestCase):
                                                                                                   {u'Ref': u'AWS::Region'},
                                                                                                   u':',
                                                                                                   {u'Ref': u'AWS::AccountId'},
-                                                                                                  ':loadbalancer/ELBdev_docker-registryservice']]}]}]},
+                                                                                                  ':loadbalancer/ELB-dev_docker-registryservice']]}]}]},
                                 u'PolicyName': 'dev_dockerregistryserviceBaseHost',
                                 u'Roles': [{u'Ref': u'BaseHostRole'}]},
                 u'Type': u'AWS::IAM::Policy'}}
@@ -602,7 +602,7 @@ class TestConfigParser(unittest.TestCase):
                                                                  {u'Ref': u'AWS::Region'},
                                                                  u':',
                                                                  {u'Ref': u'AWS::AccountId'},
-                                                                 ':loadbalancer/ELBdev_docker-registryservice']]}]}]},
+                                                                 ':loadbalancer/ELB-dev_docker-registryservice']]}]}]},
                 u'PolicyName': 'dev_dockerregistryserviceBaseHost',
                 u'Roles': [{u'Ref': u'BaseHostRole'}]},
                 u'Type': u'AWS::IAM::Policy'}}
@@ -670,7 +670,7 @@ class TestConfigParser(unittest.TestCase):
                                                                                                   {u'Ref': u'AWS::Region'},
                                                                                                   u':',
                                                                                                   {u'Ref': u'AWS::AccountId'},
-                                                                                                  ':loadbalancer/ELBdev_docker-registryservice']]}]}]},
+                                                                                                  ':loadbalancer/ELB-dev_docker-registryservice']]}]}]},
                                 u'PolicyName': 'dev_dockerregistryserviceBaseHost',
                                 u'Roles': [{u'Ref': u'BaseHostRole'}]},
                 u'Type': u'AWS::IAM::Policy'}}

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -227,6 +227,7 @@ class TestConfigParser(unittest.TestCase):
                     u'LoadBalancerName': 'ELB-test-dev-external',
                     u'SecurityGroups': [{u'Ref': u'DefaultSGtestdevexternal'}],
                     u'Scheme': 'internet-facing',
+                    u'ConnectionDrainingPolicy': {u'Enabled': True, u'Timeout': 120},
                     u'Subnets': [
                         {u'Ref': u'SubnetA'},
                         {u'Ref': u'SubnetB'},
@@ -247,18 +248,22 @@ class TestConfigParser(unittest.TestCase):
                     ]
                 },
                 u'Type': u'AWS::Route53::RecordSetGroup'}},
-            {'Policytestdevexternal': {u'Properties': {u'PolicyDocument': {u'Statement': [{u'Action': [u'elasticloadbalancing:DeregisterInstancesFromLoadBalancer',
-                                                                                            u'elasticloadbalancing:RegisterInstancesWithLoadBalancer'],
-                                                                                u'Effect': u'Allow',
-                                                                                u'Resource': [{u'Fn::Join': [u'',
-                                                                                                             [u'arn:aws:elasticloadbalancing:',
-                                                                                                              {u'Ref': u'AWS::Region'},
-                                                                                                              u':',
-                                                                                                              {u'Ref': u'AWS::AccountId'},
-                                                                                                              ':loadbalancer/ELBtest-dev-external']]}]}]},
-                                            u'PolicyName': 'testdevexternalBaseHost',
-                                            u'Roles': [{u'Ref': u'BaseHostRole'}]},
-                            u'Type': u'AWS::IAM::Policy'}},
+            {'Policytestdevexternal': {
+                u'Properties': {
+                    u'PolicyDocument': {
+                        u'Statement': [{
+                            u'Action': [u'elasticloadbalancing:DeregisterInstancesFromLoadBalancer',
+                                        u'elasticloadbalancing:RegisterInstancesWithLoadBalancer'],
+                            u'Effect': u'Allow',
+                            u'Resource': [{u'Fn::Join': [u'',
+                                                         [u'arn:aws:elasticloadbalancing:',
+                                                          {u'Ref': u'AWS::Region'},
+                                                          u':',
+                                                          {u'Ref': u'AWS::AccountId'},
+                                                          ':loadbalancer/ELBtest-dev-external']]}]}]},
+                    u'PolicyName': 'testdevexternalBaseHost',
+                    u'Roles': [{u'Ref': u'BaseHostRole'}]},
+                u'Type': u'AWS::IAM::Policy'}},
             {'ELBtestdevinternal': {
                 u'Properties': {
                     u'Listeners': [
@@ -268,6 +273,7 @@ class TestConfigParser(unittest.TestCase):
                     ],
                     u'LoadBalancerName': 'ELB-test-dev-internal',
                     u'SecurityGroups': [{u'Ref': u'DefaultSGtestdevinternal'}],
+                    u'ConnectionDrainingPolicy': {u'Enabled': True, u'Timeout': 120},
                     u'Scheme': 'internal',
                     u'Subnets': [
                         {u'Ref': u'SubnetA'},
@@ -289,18 +295,21 @@ class TestConfigParser(unittest.TestCase):
                     ]
                 },
                 u'Type': u'AWS::Route53::RecordSetGroup'}},
-            {'Policytestdevinternal': {u'Properties': {u'PolicyDocument': {u'Statement': [{u'Action': [u'elasticloadbalancing:DeregisterInstancesFromLoadBalancer',
-                                                                                            u'elasticloadbalancing:RegisterInstancesWithLoadBalancer'],
-                                                                                u'Effect': u'Allow',
-                                                                                u'Resource': [{u'Fn::Join': [u'',
-                                                                                                             [u'arn:aws:elasticloadbalancing:',
-                                                                                                              {u'Ref': u'AWS::Region'},
-                                                                                                              u':',
-                                                                                                              {u'Ref': u'AWS::AccountId'},
-                                                                                                              ':loadbalancer/ELBtest-dev-internal']]}]}]},
-                                            u'PolicyName': 'testdevinternalBaseHost',
-                                            u'Roles': [{u'Ref': u'BaseHostRole'}]},
-                            u'Type': u'AWS::IAM::Policy'}}
+            {'Policytestdevinternal': {u'Properties': {
+                u'PolicyDocument': {
+                    u'Statement': [{
+                        u'Action': [u'elasticloadbalancing:DeregisterInstancesFromLoadBalancer',
+                                    u'elasticloadbalancing:RegisterInstancesWithLoadBalancer'],
+                        u'Effect': u'Allow',
+                        u'Resource': [{u'Fn::Join': [u'',
+                                                     [u'arn:aws:elasticloadbalancing:',
+                                                      {u'Ref': u'AWS::Region'},
+                                                      u':',
+                                                      {u'Ref': u'AWS::AccountId'},
+                                                      ':loadbalancer/ELBtest-dev-internal']]}]}]},
+                        u'PolicyName': 'testdevinternalBaseHost',
+                        u'Roles': [{u'Ref': u'BaseHostRole'}]},
+                u'Type': u'AWS::IAM::Policy'}}
         ]
 
         expected_sgs = {
@@ -499,6 +508,7 @@ class TestConfigParser(unittest.TestCase):
                                                                                                                   'my-cert-my-stack-name']]}}],
                                                              'LoadBalancerName': 'ELB-dev_docker-registryservice',
                                                              'SecurityGroups': [{'Ref': 'DefaultSGdev_dockerregistryservice'}],
+                                                             u'ConnectionDrainingPolicy': {u'Enabled': True, u'Timeout': 120},
                                                              'Scheme': 'internet-facing',
                                                              'Subnets': [{'Ref': 'SubnetA'},
                                                                          {'Ref': 'SubnetB'},
@@ -513,18 +523,19 @@ class TestConfigParser(unittest.TestCase):
                                                                                'Name': 'dev_docker-registry.service.kyrtest.foo.bar.',
                                                                              'Type': 'A'}]},
                                               'Type': 'AWS::Route53::RecordSetGroup'}},
-            {'Policydev_dockerregistryservice': {u'Properties': {u'PolicyDocument': {u'Statement': [{u'Action': [u'elasticloadbalancing:DeregisterInstancesFromLoadBalancer',
-                                                                                                             u'elasticloadbalancing:RegisterInstancesWithLoadBalancer'],
-                                                                                                 u'Effect': u'Allow',
-                                                                                                 u'Resource': [{u'Fn::Join': [u'',
-                                                                                                                              [u'arn:aws:elasticloadbalancing:',
-                                                                                                                               {u'Ref': u'AWS::Region'},
-                                                                                                                               u':',
-                                                                                                                               {u'Ref': u'AWS::AccountId'},
-                                                                                                                               ':loadbalancer/ELBdev_docker-registryservice']]}]}]},
-                                                             u'PolicyName': 'dev_dockerregistryserviceBaseHost',
-                                                             u'Roles': [{u'Ref': u'BaseHostRole'}]},
-                                             u'Type': u'AWS::IAM::Policy'}}
+            {'Policydev_dockerregistryservice': {
+                u'Properties': {u'PolicyDocument': {u'Statement': [{u'Action': [u'elasticloadbalancing:DeregisterInstancesFromLoadBalancer',
+                                                                                u'elasticloadbalancing:RegisterInstancesWithLoadBalancer'],
+                                                                    u'Effect': u'Allow',
+                                                                    u'Resource': [{u'Fn::Join': [u'',
+                                                                                                 [u'arn:aws:elasticloadbalancing:',
+                                                                                                  {u'Ref': u'AWS::Region'},
+                                                                                                  u':',
+                                                                                                  {u'Ref': u'AWS::AccountId'},
+                                                                                                  ':loadbalancer/ELBdev_docker-registryservice']]}]}]},
+                                u'PolicyName': 'dev_dockerregistryserviceBaseHost',
+                                u'Roles': [{u'Ref': u'BaseHostRole'}]},
+                u'Type': u'AWS::IAM::Policy'}}
         ]
 
         project_config = ProjectConfig('tests/sample-project.yaml', 'dev')
@@ -560,6 +571,7 @@ class TestConfigParser(unittest.TestCase):
                                                                                'Protocol': 'TCP'}],
                                                              'LoadBalancerName': 'ELB-dev_docker-registryservice',
                                                              'SecurityGroups': [{'Ref': 'DefaultSGdev_dockerregistryservice'}],
+                                                             u'ConnectionDrainingPolicy': {u'Enabled': True, u'Timeout': 120},
                                                              'HealthCheck': {
                                                                  'HealthyThreshold': 10,
                                                                  'Interval': 2,
@@ -579,7 +591,21 @@ class TestConfigParser(unittest.TestCase):
                                                                                                                              'CanonicalHostedZoneNameID']}},
                                                                                'Name': 'dev_docker-registry.service.kyrtest.foo.bar.',
                                                                              'Type': 'A'}]},
-                                              'Type': 'AWS::Route53::RecordSetGroup'}}
+                                              'Type':
+                                              'AWS::Route53::RecordSetGroup'}},
+            {'Policydev_dockerregistryservice': {u'Properties': {u'PolicyDocument': {
+                u'Statement': [{u'Action': [u'elasticloadbalancing:DeregisterInstancesFromLoadBalancer',
+                                            u'elasticloadbalancing:RegisterInstancesWithLoadBalancer'],
+                                u'Effect': u'Allow',
+                                u'Resource': [{u'Fn::Join': [u'',
+                                                             [u'arn:aws:elasticloadbalancing:',
+                                                                 {u'Ref': u'AWS::Region'},
+                                                                 u':',
+                                                                 {u'Ref': u'AWS::AccountId'},
+                                                                 ':loadbalancer/ELBdev_docker-registryservice']]}]}]},
+                u'PolicyName': 'dev_dockerregistryserviceBaseHost',
+                u'Roles': [{u'Ref': u'BaseHostRole'}]},
+                u'Type': u'AWS::IAM::Policy'}}
         ]
         project_config = ProjectConfig('tests/sample-project.yaml', 'dev')
         project_config.config['elb'] = [{
@@ -620,6 +646,7 @@ class TestConfigParser(unittest.TestCase):
                                                                                'Protocol': 'TCP'}],
                                                              'LoadBalancerName': 'ELB-dev_docker-registryservice',
                                                              'SecurityGroups': [{'Ref': 'DefaultSGdev_dockerregistryservice'}],
+                                                             u'ConnectionDrainingPolicy': {u'Enabled': True, u'Timeout': 120},
                                                              'Scheme': 'internet-facing',
                                                              'Subnets': [{'Ref': 'SubnetA'},
                                                                          {'Ref': 'SubnetB'},
@@ -634,18 +661,19 @@ class TestConfigParser(unittest.TestCase):
                                                                                'Name': 'dev_docker-registry.service.kyrtest.foo.bar.',
                                                                              'Type': 'A'}]},
                                               'Type': 'AWS::Route53::RecordSetGroup'}},
-            {'Policydev_dockerregistryservice': {u'Properties': {u'PolicyDocument': {u'Statement': [{u'Action': [u'elasticloadbalancing:DeregisterInstancesFromLoadBalancer',
-                                                                                                             u'elasticloadbalancing:RegisterInstancesWithLoadBalancer'],
-                                                                                                 u'Effect': u'Allow',
-                                                                                                 u'Resource': [{u'Fn::Join': [u'',
-                                                                                                                              [u'arn:aws:elasticloadbalancing:',
-                                                                                                                               {u'Ref': u'AWS::Region'},
-                                                                                                                               u':',
-                                                                                                                               {u'Ref': u'AWS::AccountId'},
-                                                                                                                               ':loadbalancer/ELBdev_docker-registryservice']]}]}]},
-                                                             u'PolicyName': 'dev_dockerregistryserviceBaseHost',
-                                                             u'Roles': [{u'Ref': u'BaseHostRole'}]},
-                                             u'Type': u'AWS::IAM::Policy'}}
+            {'Policydev_dockerregistryservice': {
+                u'Properties': {u'PolicyDocument': {u'Statement': [{u'Action': [u'elasticloadbalancing:DeregisterInstancesFromLoadBalancer',
+                                                                                u'elasticloadbalancing:RegisterInstancesWithLoadBalancer'],
+                                                                    u'Effect': u'Allow',
+                                                                    u'Resource': [{u'Fn::Join': [u'',
+                                                                                                 [u'arn:aws:elasticloadbalancing:',
+                                                                                                  {u'Ref': u'AWS::Region'},
+                                                                                                  u':',
+                                                                                                  {u'Ref': u'AWS::AccountId'},
+                                                                                                  ':loadbalancer/ELBdev_docker-registryservice']]}]}]},
+                                u'PolicyName': 'dev_dockerregistryserviceBaseHost',
+                                u'Roles': [{u'Ref': u'BaseHostRole'}]},
+                u'Type': u'AWS::IAM::Policy'}}
         ]
 
         project_config = ProjectConfig('tests/sample-project.yaml', 'dev')

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -55,6 +55,9 @@ class TestConfigParser(unittest.TestCase):
                                                                                   {'Action': ['rds:Describe*'],
                                                                                    'Resource': '*',
                                                                                    'Effect': 'Allow'},
+                                                                                  {'Action': ['elasticloadbalancing:Describe*'],
+                                                                                   'Resource': '*',
+                                                                                   'Effect': 'Allow'},
                                                                                   {'Action': ['elasticache:Describe*'],
                                                                                    'Resource': '*',
                                                                                    'Effect': 'Allow'},
@@ -244,6 +247,18 @@ class TestConfigParser(unittest.TestCase):
                     ]
                 },
                 u'Type': u'AWS::Route53::RecordSetGroup'}},
+            {'Policytestdevexternal': {u'Properties': {u'PolicyDocument': {u'Statement': [{u'Action': [u'elasticloadbalancing:DeregisterInstancesFromLoadBalancer',
+                                                                                            u'elasticloadbalancing:RegisterInstancesWithLoadBalancer'],
+                                                                                u'Effect': u'Allow',
+                                                                                u'Resource': [{u'Fn::Join': [u'',
+                                                                                                             [u'arn:aws:elasticloadbalancing:',
+                                                                                                              {u'Ref': u'AWS::Region'},
+                                                                                                              u':',
+                                                                                                              {u'Ref': u'AWS::AccountId'},
+                                                                                                              ':loadbalancer/ELBtest-dev-external']]}]}]},
+                                            u'PolicyName': 'testdevexternalBaseHost',
+                                            u'Roles': [{u'Ref': u'BaseHostRole'}]},
+                            u'Type': u'AWS::IAM::Policy'}},
             {'ELBtestdevinternal': {
                 u'Properties': {
                     u'Listeners': [
@@ -274,6 +289,18 @@ class TestConfigParser(unittest.TestCase):
                     ]
                 },
                 u'Type': u'AWS::Route53::RecordSetGroup'}},
+            {'Policytestdevinternal': {u'Properties': {u'PolicyDocument': {u'Statement': [{u'Action': [u'elasticloadbalancing:DeregisterInstancesFromLoadBalancer',
+                                                                                            u'elasticloadbalancing:RegisterInstancesWithLoadBalancer'],
+                                                                                u'Effect': u'Allow',
+                                                                                u'Resource': [{u'Fn::Join': [u'',
+                                                                                                             [u'arn:aws:elasticloadbalancing:',
+                                                                                                              {u'Ref': u'AWS::Region'},
+                                                                                                              u':',
+                                                                                                              {u'Ref': u'AWS::AccountId'},
+                                                                                                              ':loadbalancer/ELBtest-dev-internal']]}]}]},
+                                            u'PolicyName': 'testdevinternalBaseHost',
+                                            u'Roles': [{u'Ref': u'BaseHostRole'}]},
+                            u'Type': u'AWS::IAM::Policy'}}
         ]
 
         expected_sgs = {
@@ -485,7 +512,19 @@ class TestConfigParser(unittest.TestCase):
                                                                                                                              'CanonicalHostedZoneNameID']}},
                                                                                'Name': 'dev_docker-registry.service.kyrtest.foo.bar.',
                                                                              'Type': 'A'}]},
-                                              'Type': 'AWS::Route53::RecordSetGroup'}}
+                                              'Type': 'AWS::Route53::RecordSetGroup'}},
+            {'Policydev_dockerregistryservice': {u'Properties': {u'PolicyDocument': {u'Statement': [{u'Action': [u'elasticloadbalancing:DeregisterInstancesFromLoadBalancer',
+                                                                                                             u'elasticloadbalancing:RegisterInstancesWithLoadBalancer'],
+                                                                                                 u'Effect': u'Allow',
+                                                                                                 u'Resource': [{u'Fn::Join': [u'',
+                                                                                                                              [u'arn:aws:elasticloadbalancing:',
+                                                                                                                               {u'Ref': u'AWS::Region'},
+                                                                                                                               u':',
+                                                                                                                               {u'Ref': u'AWS::AccountId'},
+                                                                                                                               ':loadbalancer/ELBdev_docker-registryservice']]}]}]},
+                                                             u'PolicyName': 'dev_dockerregistryserviceBaseHost',
+                                                             u'Roles': [{u'Ref': u'BaseHostRole'}]},
+                                             u'Type': u'AWS::IAM::Policy'}}
         ]
 
         project_config = ProjectConfig('tests/sample-project.yaml', 'dev')
@@ -594,7 +633,19 @@ class TestConfigParser(unittest.TestCase):
                                                                                                                              'CanonicalHostedZoneNameID']}},
                                                                                'Name': 'dev_docker-registry.service.kyrtest.foo.bar.',
                                                                              'Type': 'A'}]},
-                                              'Type': 'AWS::Route53::RecordSetGroup'}}
+                                              'Type': 'AWS::Route53::RecordSetGroup'}},
+            {'Policydev_dockerregistryservice': {u'Properties': {u'PolicyDocument': {u'Statement': [{u'Action': [u'elasticloadbalancing:DeregisterInstancesFromLoadBalancer',
+                                                                                                             u'elasticloadbalancing:RegisterInstancesWithLoadBalancer'],
+                                                                                                 u'Effect': u'Allow',
+                                                                                                 u'Resource': [{u'Fn::Join': [u'',
+                                                                                                                              [u'arn:aws:elasticloadbalancing:',
+                                                                                                                               {u'Ref': u'AWS::Region'},
+                                                                                                                               u':',
+                                                                                                                               {u'Ref': u'AWS::AccountId'},
+                                                                                                                               ':loadbalancer/ELBdev_docker-registryservice']]}]}]},
+                                                             u'PolicyName': 'dev_dockerregistryserviceBaseHost',
+                                                             u'Roles': [{u'Ref': u'BaseHostRole'}]},
+                                             u'Type': u'AWS::IAM::Policy'}}
         ]
 
         project_config = ProjectConfig('tests/sample-project.yaml', 'dev')


### PR DESCRIPTION
The aim of this PR is to make it possible to orchestrate zero downtime deployments.
- Allow instances to register/deregister with ELB
- Enable connection draining to maintain existing connections.
