### PR TITLE
[enable_cert_updates]

### DIFF
--- a/bootstrap_cfn/iam.py
+++ b/bootstrap_cfn/iam.py
@@ -1,7 +1,5 @@
 import boto.iam
 from boto.connection import AWSQueryConnection
-from boto.exception import NoAuthHandlerFound
-from boto.provider import ProfileNotFoundError
 from bootstrap_cfn import utils
 import logging
 from bootstrap_cfn.errors import CloudResourceNotFoundError
@@ -31,18 +29,18 @@ class IAM:
         for cert_name, ssl_data in ssl_config.items():
             self.delete_certificate(cert_name,
                                     stack_name,
-                                    ssl_data,
-                                    force=True)
+                                    ssl_data)
         return True
 
     def update_ssl_certificates(self, ssl_config, stack_name):
         """
-        Update all the ssl certificates in the identified stack. Raise an 
+        Update all the ssl certificates in the identified stack. Raise an
         exception if we try to update a non-existent certificate
 
         Args:
-            ssl_config(dictionary): A dictionary of ssl configuration data organised by
-                cert_name to a dictionary with the config data in it
+            ssl_config(dictionary): A dictionary of ssl configuration data
+                organised by cert_name to a dictionary with the config
+                data in it
             stack_name(string): The name of the stack
 
         Returns:
@@ -71,7 +69,7 @@ class IAM:
                     else:
                         msg = ("IAM::update_ssl_certificates: "
                                "Could not update certificate '%s': "
-                               "Certificate does not exist remotely" 
+                               "Certificate does not exist remotely"
                                % (cert_name))
                         raise CloudResourceNotFoundError(msg)
 
@@ -118,7 +116,7 @@ class IAM:
                                                    None),
             }
             return remote_cert_data
-        # Handle any problems connecting to the remote AWS 
+        # Handle any problems connecting to the remote AWS
         except AWSQueryConnection.ResponseError as error:
                     logging.info("IAM::get_remote_certificate: "
                                  "Could not find certificate '%s': "
@@ -174,7 +172,7 @@ class IAM:
                              "certificate id '%s' "
                              % (cert_id))
                 return False
-        # Handle any problems connecting to the remote AWS 
+        # Handle any problems connecting to the remote AWS
         except AWSQueryConnection.ResponseError as error:
                     logging.info("IAM::get_remote_certificate: "
                                  "Could not find certificate '%s': "
@@ -201,8 +199,7 @@ class IAM:
         """
 
         are_equal = False
-        certs_are_equal = self.compare_certs_body(
-                                                  cert_data1.get("cert", None),
+        certs_are_equal = self.compare_certs_body(cert_data1.get("cert", None),
                                                   cert_data2.get("cert", None))
         if not certs_are_equal:
             logging.info("IAM::compare_certificate_data: "
@@ -259,8 +256,8 @@ class IAM:
 
         try:
             if force or not self.get_remote_certificate(cert_name,
-                                                                 stack_name,
-                                                                 ssl_data):
+                                                        stack_name,
+                                                        ssl_data):
                 self.conn_iam.upload_server_cert(cert_id, cert_body,
                                                  private_key,
                                                  cert_chain)

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -1,4 +1,3 @@
-import bootstrap_cfn
 from bootstrap_cfn import iam
 import unittest
 from nose.tools import raises
@@ -72,25 +71,26 @@ class TestIAM(unittest.TestCase):
         }
 
     cert1_remote_get_certificate_response = \
-    {
-        "get_server_certificate_response":
+        {
+            "get_server_certificate_response":
             {
-             "get_server_certificate_result": 
+                "get_server_certificate_result":
                 {
-                    "server_certificate": {
-                                           "certificate_body": ("-----BEGIN CERTIFICATE-----"
-                                                                "CERT1CERT1CERT1CERT1CERT1CER"
-                                                                "-----END CERTIFICATE-----"),
-                                           "certificate_chain": ("-----BEGIN CERTIFICATE-----"
-                                                                 "CHAIN1CHAIN1CHAIN1CHAIN1CHA"
-                                                                 "-----END CERTIFICATE-----"),
-                                           "certificate_key": ("-----BEGIN PRIVATE KEY-----"
-                                                               "KEY1KEY1KEY1KEY1KEY1KEY1KEY"
-                                                               "-----END PRIVATE KEY-----")
-                                           }
-                 }
-             }
-    }
+                    "server_certificate":
+                    {
+                        "certificate_body": ("-----BEGIN CERTIFICATE-----"
+                                             "CERT1CERT1CERT1CERT1CERT1CER"
+                                             "-----END CERTIFICATE-----"),
+                        "certificate_chain": ("-----BEGIN CERTIFICATE-----"
+                                              "CHAIN1CHAIN1CHAIN1CHAIN1CHA"
+                                              "-----END CERTIFICATE-----"),
+                        "certificate_key": ("-----BEGIN PRIVATE KEY-----"
+                                            "KEY1KEY1KEY1KEY1KEY1KEY1KEY"
+                                            "-----END PRIVATE KEY-----"),
+                        }
+                    }
+                }
+            }
     successful_response = \
         {
             "status": 200,
@@ -128,7 +128,7 @@ class TestIAM(unittest.TestCase):
         stack_name = "test_stack"
 
         update_list = self.mock_iam.update_ssl_certificates(ssl_config,
-                                                             stack_name)
+                                                            stack_name)
         self.assertEqual(len(update_list),
                          2,
                          "TestIAM::test_update_ssl_certificates_force: "
@@ -148,9 +148,9 @@ class TestIAM(unittest.TestCase):
         non existing certificates
         """
         mock_get_remote_certificate.side_effect = [True,
-                                                            False,
-                                                            False,
-                                                            None]
+                                                   False,
+                                                   False,
+                                                   None]
         mock_upload_server_cert.side_effect = [self.successful_response,
                                                self.unsuccessful_response,
                                                None]
@@ -170,8 +170,8 @@ class TestIAM(unittest.TestCase):
     @patch("boto.iam.IAMConnection.upload_server_cert")
     @patch("bootstrap_cfn.iam.IAM.get_remote_certificate")
     def test_upload_certificate_not_exists(self,
-                                mock_get_remote_certificate,
-                                mock_upload_server_cert):
+                                           mock_get_remote_certificate,
+                                           mock_upload_server_cert):
         """
         Test that we can upload a certificate if it doesnt exist remotely
         """
@@ -180,8 +180,9 @@ class TestIAM(unittest.TestCase):
         cert_name = "cert1"
         stack_name = "test_stack"
         ssl_data = self.test_certs["test_cert_1"]
-        force = False
-        success = self.mock_iam.upload_certificate(cert_name, stack_name, ssl_data, force)
+        success = self.mock_iam.upload_certificate(cert_name,
+                                                   stack_name,
+                                                   ssl_data)
         self.assertTrue(success,
                         "TestIAM::test_upload_certificate_exists: "
                         "Should be able to upload a non existent cert "
@@ -190,8 +191,8 @@ class TestIAM(unittest.TestCase):
     @patch("boto.iam.IAMConnection.upload_server_cert")
     @patch("bootstrap_cfn.iam.IAM.get_remote_certificate")
     def test_upload_certificate_exists(self,
-                                mock_get_remote_certificate,
-                                mock_upload_server_cert):
+                                       mock_get_remote_certificate,
+                                       mock_upload_server_cert):
         """
         Test that we cannot upload a certificate if it exists remotely
         """
@@ -200,13 +201,14 @@ class TestIAM(unittest.TestCase):
         cert_name = "cert1"
         stack_name = "test_stack"
         ssl_data = self.test_certs["test_cert_1"]
-        force = False
-        success = self.mock_iam.upload_certificate(cert_name, stack_name, ssl_data, force)
+        success = self.mock_iam.upload_certificate(cert_name,
+                                                   stack_name,
+                                                   ssl_data)
         self.assertFalse(success,
-                        "TestIAM::test_upload_certificate_exists: "
-                        "Should not be able to upload an existent cert "
-                        )
-        
+                         "TestIAM::test_upload_certificate_exists: "
+                         "Should not be able to upload an existent cert "
+                         )
+
     @patch("boto.iam.IAMConnection.delete_server_cert")
     @patch("bootstrap_cfn.iam.IAM.get_remote_certificate")
     def test_delete_certificate_exists(self,
@@ -221,11 +223,13 @@ class TestIAM(unittest.TestCase):
         stack_name = "test_stack"
         ssl_data = self.test_certs["test_cert_1"]
 
-        success = self.mock_iam.delete_certificate(cert_name, stack_name, ssl_data)
+        success = self.mock_iam.delete_certificate(cert_name,
+                                                   stack_name,
+                                                   ssl_data)
         self.assertTrue(success,
-                         "TestIAM::test_delete_certificate_exists: "
-                         "Should only be able to delete an existent cert "
-                         )
+                        "TestIAM::test_delete_certificate_exists: "
+                        "Should only be able to delete an existent cert "
+                        )
 
     @patch("boto.iam.IAMConnection.delete_server_cert")
     @patch("bootstrap_cfn.iam.IAM.get_remote_certificate")
@@ -241,7 +245,9 @@ class TestIAM(unittest.TestCase):
         stack_name = "test_stack"
         ssl_data = self.test_certs["test_cert_1"]
 
-        success = self.mock_iam.delete_certificate(cert_name, stack_name, ssl_data)
+        success = self.mock_iam.delete_certificate(cert_name,
+                                                   stack_name,
+                                                   ssl_data)
         self.assertFalse(success,
                          "TestIAM::test_delete_certificate_not_exists: "
                          "Should not be able to delete "
@@ -251,15 +257,15 @@ class TestIAM(unittest.TestCase):
         local_cert_data = self.test_certs["test_cert_1"]
         remote_cert = self.remote_test_certs["test_cert_1"]
         remote_cert_data = \
-        {
-         "cert": remote_cert["certificate_body"],
-         "chain": remote_cert["certificate_chain"],
-         "key": remote_cert["certificate_key"],
-         }
-        certs_equal = self.mock_iam.compare_certificate_data(local_cert_data, 
+            {
+                "cert": remote_cert["certificate_body"],
+                "chain": remote_cert["certificate_chain"],
+                "key": remote_cert["certificate_key"],
+            }
+        certs_equal = self.mock_iam.compare_certificate_data(local_cert_data,
                                                              remote_cert_data)
 
-        self.assertTrue(certs_equal, 
+        self.assertTrue(certs_equal,
                         "Local and remote certificates should be equal")
 
     def test_compare_certificates_unequal(self):
@@ -269,10 +275,10 @@ class TestIAM(unittest.TestCase):
 
         # Test when cert is different
         remote_cert_data = \
-        {
-         "cert": remote_cert2["certificate_body"],
-         "chain": remote_cert1["certificate_chain"],
-         }
+            {
+                "cert": remote_cert2["certificate_body"],
+                "chain": remote_cert1["certificate_chain"],
+            }
         certs_equal = self.mock_iam.compare_certificate_data(local_cert_data,
                                                              remote_cert_data)
 
@@ -282,10 +288,10 @@ class TestIAM(unittest.TestCase):
 
         # Test when chain is different
         remote_cert_data = \
-        {
-         "cert": remote_cert1["certificate_body"],
-         "chain": remote_cert2["certificate_chain"],
-         }
+            {
+                "cert": remote_cert1["certificate_body"],
+                "chain": remote_cert2["certificate_chain"],
+            }
         certs_equal = self.mock_iam.compare_certificate_data(local_cert_data,
                                                              remote_cert_data)
 


### PR DESCRIPTION
Fix for a little problem introduced in enable_cert_updates merge
- Remove deprecated force argument being passed to
  iam::delete_certificate
