### PR TITLE
Don't install tests/ folder into python module path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Version 0.4.x (Unreleased)
+
+* Fix dist to not include tests/ folder
+
+  This would cause problems for downstream modules (i.e. bootstrap-salt) as
+  they would then try to run our tests, but wouldn't have half the needed test
+  modules.
+
 ## Version 0.4.0
 
 First release to PyPi

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,0 @@
-include CHANGELOG.md LICENSE AUTHORS
-recursive-include scripts *
-recursive-include docs *
-recursive-include tests *

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     author_email='tools@digital.justice.gov.uk',
     description='MOJDS cloudformation bootstrap tool',
     long_description=__doc__,
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     package_data={'bootstrap_cfn': ['stacks/*']},
     zip_safe=False,
     platforms='any',


### PR DESCRIPTION
Exclude it from the list of packages installed by setup.py

MANIFEST.in isn't needed for modern dists, using packages and
package_data is enough
