### PR TITLE
Support multiple stacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+##
+
+* Make it possible to create multiple stacks with the same app and env.
+
 ## Version 0.5.0
 
 * Enable connection draining on ELBs

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,24 @@ If your ``$CWD`` is anywhere else, you need to pass in a path to particular fabr
 - **environment:dev** - The ``dev`` section will be read from the projects YAML file (line 1 in the example below)
 - **config:/path/to/file.yaml** - The location to the project YAML file
 
+Multiple Stacks
+=================
+
+If you want to run multiple stacks with the same name and environment place the following in the yaml configuration::
+
+    master_zone:
+      my-zone.dsd.io
+
+Then when you create a stack you can specify a tag before cfn_create, like::
+
+    fab application:courtfinder aws:my_project_prod environment:dev config:/path/to/courtfinder-dev.yaml tag:active cfn_create
+
+NB active is the default.
+
+Then you can refer to this stack by it's tag in the future. In this way it is easier to bring up two stacks from the same config. If you want to swap the names of the stacks you can do the following::
+
+    fab application:courtfinder aws:my_project_prod environment:dev config:/path/to/courtfinder-dev.yaml swap_tags:inactive,active
+
 Example Configuration
 =====================
 AWS Account Configuration

--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -13,7 +13,10 @@ from bootstrap_cfn.config import ProjectConfig, ConfigParser
 from bootstrap_cfn.cloudformation import Cloudformation
 from bootstrap_cfn.iam import IAM
 from bootstrap_cfn.elb import ELB
+from bootstrap_cfn.r53 import R53
 from bootstrap_cfn.utils import tail
+from boto.route53.exception import DNSServerError
+import uuid
 
 
 # Default fab config. Set via the tasks below or --set
@@ -83,6 +86,24 @@ def application(application_name):
 
 
 @task
+def tag(tag):
+    """
+    Set a tag for the stack
+
+    Sets the environment variable 'tag'
+    This gets used to store a DNS entry to identify
+    multiple stacks with the same name.
+    e.g. you can tag a stack as active, or inactive,
+    green or blue etc.
+
+    Args:
+        tag(string): The string to set the
+        variable to
+    """
+    env.tag = str(tag).lower()
+
+
+@task
 def config(config_file):
     """
     Set the location of the project's YAML file
@@ -148,16 +169,111 @@ def user(username):
     env.user = username
 
 
+def generate_stack_name():
+    """
+    Used to generate new stack name.
+
+    Format <application>-<environment>-<tag>
+
+    tag is optional and defaults to 'active'
+    """
+    if hasattr(env, 'tag'):
+        tag = env.tag
+    else:
+        tag = 'active'
+        env.tag = tag
+    legacy_name = "{0}-{1}".format(env.application, env.environment)
+    cfn_config = get_config()
+    try:
+        r53_conn = get_connection(R53)
+        zone_name = cfn_config.data['master_zone']
+        zone_id = r53_conn.get_hosted_zone_id(zone_name)
+        record_name = "stack.{0}.{1}".format(tag, legacy_name)
+        stack_suffix = uuid.uuid4().__str__()[-8:]
+        record = "{0}.{1}".format(record_name, zone_name)
+        r53_conn.update_dns_record(zone_id, record, 'TXT', '"{0}"'.format(stack_suffix))
+        env.stack_name = "{0}-{1}".format(legacy_name, stack_suffix)
+    except KeyError:
+        logging.warn("No master_zone in yaml, unable to create DNS records for "
+                     "stack name, will fallback to legacy stack names: "
+                     "application-environment")
+        env.stack_name = legacy_name
+    except DNSServerError:
+        logging.warn("Couldn't create DNS entry for stack suffix, "
+                     "stack name, will fallback to legacy stack names: "
+                     "application-environment")
+        env.stack_name = legacy_name
+    return env.stack_name
+
+
+@task
+def swap_tags(tag1, tag2):
+    """
+    Swap two tagged stacks.
+
+    i.e. update the DNS text record which defines the
+    random suffix associated with a stack tag.
+    """
+    cfn_config = get_config()
+    r53_conn = get_connection(R53)
+    zone_name = cfn_config.data['master_zone']
+    zone_id = r53_conn.get_hosted_zone_id(zone_name)
+    legacy_name = "{0}-{1}".format(env.application, env.environment)
+    record1 = "stack.{0}.{1}".format(tag1, legacy_name)
+    record2 = "stack.{0}.{1}".format(tag2, legacy_name)
+    stack_suffix1 = r53_conn.get_record(zone_name, zone_id, record1, 'TXT')
+    stack_suffix2 = r53_conn.get_record(zone_name, zone_id, record2, 'TXT')
+    fqdn1 = "{0}.{1}".format(record1, zone_name)
+    fqdn2 = "{0}.{1}".format(record2, zone_name)
+    r53_conn.update_dns_record(zone_id, fqdn1, 'TXT', '"{0}"'.format(stack_suffix2))
+    r53_conn.update_dns_record(zone_id, fqdn2, 'TXT', '"{0}"'.format(stack_suffix1))
+
+
 def get_stack_name():
     """
     Get the name of the stack
 
     The name of the stack is a combination
     of the application and environment names
+    and a randomly generated suffix.
+
+    The env.tag dictates which randomly generated suffix
+    the default env.tag is 'active'
+
     """
-    if hasattr(env, 'stack_name'):
-        return env.stack_name
-    return "%s-%s" % (env.application, env.environment)
+    if hasattr(env, 'tag'):
+        tag = env.tag
+    else:
+        tag = 'active'
+        env.tag = tag
+    if not hasattr(env, 'stack_name'):
+        legacy_name = "{0}-{1}".format(env.application, env.environment)
+        # get_config needs a stack_name so this is a hack because we don't
+        # know it yet...
+        env.stack_name = 'temp'
+        cfn_config = get_config()
+        try:
+            r53_conn = get_connection(R53)
+            zone_name = cfn_config.data['master_zone']
+            zone_id = r53_conn.get_hosted_zone_id(zone_name)
+            record_name = "stack.{0}.{1}".format(tag, legacy_name)
+            stack_suffix = r53_conn.get_record(zone_name, zone_id, record_name, 'TXT')
+            if stack_suffix:
+                env.stack_name = "{0}-{1}".format(legacy_name, stack_suffix)
+            else:
+                env.stack_name = legacy_name
+        except (DNSServerError, KeyError):
+            logging.warn("No master_zone in yaml, unable to create DNS records for "
+                         "stack name, will fallback to legacy stack names: "
+                         "application-environment")
+            env.stack_name = legacy_name
+        except DNSServerError:
+            logging.warn("Couldn't find DNS entry for stack suffix, "
+                         "stack name, will fallback to legacy stack names: "
+                         "application-environment")
+            env.stack_name = legacy_name
+    print env.stack_name
+    return env.stack_name
 
 
 def _validate_fabric_env():
@@ -242,7 +358,7 @@ def cfn_create():
     specification will be generated and used to create a
     stack on AWS.
     """
-    stack_name = get_stack_name()
+    stack_name = generate_stack_name()
     cfn_config = get_config()
 
     cfn = get_connection(Cloudformation)

--- a/bootstrap_cfn/r53.py
+++ b/bootstrap_cfn/r53.py
@@ -1,0 +1,47 @@
+import boto.route53
+import utils
+
+
+class R53:
+
+    conn_cfn = None
+    aws_region_name = None
+    aws_profile_name = None
+
+    def __init__(self, aws_profile_name, aws_region_name='eu-west-1'):
+        self.aws_profile_name = aws_profile_name
+        self.aws_region_name = aws_region_name
+
+        self.conn_r53 = utils.connect_to_aws(boto.route53, self)
+
+    def get_hosted_zone_id(self, zone_name):
+        '''
+        Take a zone name
+        Return a zone id or None if no zone found
+        '''
+        zone = self.conn_r53.get_hosted_zone_by_name(zone_name)
+        if zone:
+            zone = zone['GetHostedZoneResponse']['HostedZone']['Id']
+            return zone.replace('/hostedzone/', '')
+
+    def update_dns_record(self, zone, record, record_type, record_value):
+        '''
+        Returns True if update successful or raises an exception if not
+        '''
+        changes = boto.route53.record.ResourceRecordSets(self.conn_r53, zone)
+        change = changes.add_change("UPSERT", record, record_type, ttl=60)
+        change.add_value(record_value)
+        changes.commit()
+        return True
+
+    def get_record(self, zone, zone_id, record, record_type):
+        '''
+        '''
+        fqdn = "{0}.{1}.".format(record, zone)
+        rrsets = self.conn_r53.get_all_rrsets(zone_id, type=record_type, name=fqdn)
+        for rr in rrsets:
+            if rr.type == record_type and rr.name == fqdn:
+                if rr.type == 'TXT':
+                    rr.resource_records[0] = rr.resource_records[0][1:-1]
+                return rr.resource_records[0]
+        return None

--- a/tests/test_r53.py
+++ b/tests/test_r53.py
@@ -1,0 +1,74 @@
+from bootstrap_cfn import r53
+import unittest
+import tempfile
+import boto.route53
+import mock
+import os
+
+
+class BootstrapCfnR53TestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.work_dir = tempfile.mkdtemp()
+        self.env = mock.Mock()
+        self.env.aws = 'dev'
+        self.env.aws_profile = 'the-profile-name'
+        self.env.environment = 'dev'
+        self.env.application = 'unittest-app'
+        self.env.config = os.path.join(self.work_dir, 'test_config.yaml')
+
+    def test_update_dns_record(self):
+        r53_mock = mock.Mock()
+        r53_connect_result = mock.Mock(name='cf_connect')
+        r53_mock.return_value = r53_connect_result
+        boto.route53.connect_to_region = r53_mock
+        r = r53.R53(self.env.aws_profile)
+        x = r.update_dns_record('blah/blah', 'x.y', 'A', '1.1.1.1')
+        self.assertTrue(x)
+
+    def test_get_hosted_zone_id(self):
+        r53_mock = mock.Mock()
+        r53_connect_result = mock.Mock(name='cf_connect')
+        r53_mock.return_value = r53_connect_result
+        response = {'GetHostedZoneResponse': {}}
+        zone_response = {'HostedZone': {'Id': 'blah/blah'}}
+        response['GetHostedZoneResponse'] = zone_response
+
+        mock_config = {'get_hosted_zone_by_name.return_value': response}
+        r53_connect_result.configure_mock(**mock_config)
+        boto.route53.connect_to_region = r53_mock
+        r = r53.R53(self.env.aws_profile)
+        x = r.get_hosted_zone_id('blah')
+        self.assertEquals(x, 'blah/blah')
+
+    def test_get_record(self):
+        r53_mock = mock.Mock()
+        r53_connect_result = mock.Mock(name='cf_connect')
+        r53_mock.return_value = r53_connect_result
+        m = mock.Mock(resource_records=['1.1.1.1'])
+        m.name = 'blah.dsd.io.'
+        m.type = 'A'
+        response = [m]
+
+        mock_config = {'get_all_rrsets.return_value': response}
+        r53_connect_result.configure_mock(**mock_config)
+        boto.route53.connect_to_region = r53_mock
+        r = r53.R53(self.env.aws_profile)
+        x = r.get_record('dsd.io', 'ASDAKSLDK', 'blah', 'A')
+        self.assertEquals(x, '1.1.1.1')
+
+    def test_get_TXT_record(self):
+        r53_mock = mock.Mock()
+        r53_connect_result = mock.Mock(name='cf_connect')
+        r53_mock.return_value = r53_connect_result
+        m = mock.Mock(resource_records=['"lollol"'])
+        m.name = 'blah.dsd.io.'
+        m.type = 'TXT'
+        response = [m]
+
+        mock_config = {'get_all_rrsets.return_value': response}
+        r53_connect_result.configure_mock(**mock_config)
+        boto.route53.connect_to_region = r53_mock
+        r = r53.R53(self.env.aws_profile)
+        x = r.get_record('dsd.io', 'ASDAKSLDK', 'blah', 'TXT')
+        self.assertEquals(x, 'lollol')


### PR DESCRIPTION
This makes it easier to create multiple stacks of the same app and environment. It adds a random string after the stack name so that it does not clash, this is associated with a tag, such as inactive or active.

This doesn't solve the whole problem because some resources still need renaming (i.e. dns-names, S3 buckets). However you no longer need to rename all references to an environment e.g. renaming prod to prod1.

A change is also needed to bootstrap-salt (PR to follow).

I _think_ this is backwards compatible. But it is more code than I wanted to write...

Needs some docs.
