### PR TITLE
Fix Remote Deletion of SSL Certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+* Fix bug where certificates were not being deleted on calls to upload or
+delete due to a broken method call to get_remote_certificates
+
 ## Version 0.5.1
 
 * Make it possible to create multiple stacks with the same app and env.

--- a/bootstrap_cfn/iam.py
+++ b/bootstrap_cfn/iam.py
@@ -256,8 +256,7 @@ class IAM:
 
         try:
             if force or not self.get_remote_certificate(cert_name,
-                                                        stack_name,
-                                                        ssl_data):
+                                                        stack_name):
                 self.conn_iam.upload_server_cert(cert_id, cert_body,
                                                  private_key,
                                                  cert_chain)
@@ -300,8 +299,7 @@ class IAM:
         # continue to delete other certs
         try:
             if self.get_remote_certificate(cert_name,
-                                           stack_name,
-                                           ssl_data):
+                                           stack_name):
                 self.conn_iam.delete_server_cert(cert_id)
                 logging.info("IAM::delete_certificate: "
                              "Deleting certificate '%s'.."

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -183,6 +183,8 @@ class TestIAM(unittest.TestCase):
         success = self.mock_iam.upload_certificate(cert_name,
                                                    stack_name,
                                                    ssl_data)
+        mock_get_remote_certificate.assert_called_once_with(cert_name,
+                                                            stack_name)
         self.assertTrue(success,
                         "TestIAM::test_upload_certificate_exists: "
                         "Should be able to upload a non existent cert "
@@ -204,6 +206,8 @@ class TestIAM(unittest.TestCase):
         success = self.mock_iam.upload_certificate(cert_name,
                                                    stack_name,
                                                    ssl_data)
+        mock_get_remote_certificate.assert_called_once_with(cert_name,
+                                                            stack_name)
         self.assertFalse(success,
                          "TestIAM::test_upload_certificate_exists: "
                          "Should not be able to upload an existent cert "
@@ -226,6 +230,8 @@ class TestIAM(unittest.TestCase):
         success = self.mock_iam.delete_certificate(cert_name,
                                                    stack_name,
                                                    ssl_data)
+        mock_get_remote_certificate.assert_called_once_with(cert_name,
+                                                            stack_name)
         self.assertTrue(success,
                         "TestIAM::test_delete_certificate_exists: "
                         "Should only be able to delete an existent cert "
@@ -248,6 +254,8 @@ class TestIAM(unittest.TestCase):
         success = self.mock_iam.delete_certificate(cert_name,
                                                    stack_name,
                                                    ssl_data)
+        mock_get_remote_certificate.assert_called_once_with(cert_name,
+                                                            stack_name)
         self.assertFalse(success,
                          "TestIAM::test_delete_certificate_not_exists: "
                          "Should not be able to delete "


### PR DESCRIPTION
get_remote_certificate doesnt need ssl data passed anymore,
this makes sure that no more calls pass this argument

Closes (but only once we release a version) ministryofjustice/template-deploy#62
