### PR TITLE
Print additional values from the exception object when cfn_create fails.

### DIFF
--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -341,8 +341,9 @@ def cfn_create():
     # Inject security groups in stack template and create stacks.
     try:
         stack = cfn.create(stack_name, cfn_config.process())
-    except Exception as e:
-        abort(red("Failed to create: {error}".format(error=e.message)))
+    except:
+        import traceback
+        abort(red("Failed to create: {error}".format(error=traceback.format_exc())))
 
     print green("\nSTACK {0} CREATING...\n").format(stack_name)
 


### PR DESCRIPTION
  If cfn_create fails, right now the code only prints the message value, which is sometimes empty,
  while strerror, errno and filename contain useful information.
  The empty message can be confusing and require time to troubleshoot.
  This PR to fix ministryofjustice/bootstrap-cfn#110
