### PR TITLE
Add SSL certificates cleanup when cfn_create fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.5.3 [WIP]
+* Improve message content when cfn_create raises an exception and fails.
+* Cleanup SSL certificates when cfn_create raises an exception and fails.
+
 ## Version 0.5.2
 
 * Fix bug where certificates were not being deleted on calls to upload or

--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -334,6 +334,7 @@ def cfn_create():
     cfn = get_connection(Cloudformation)
     # Upload any SSL certs that we may need for the stack.
     if 'ssl' in cfn_config.data:
+        print green("Uploading SSL certificates to stack")
         iam = get_connection(IAM)
         iam.upload_ssl_certificate(cfn_config.ssl(), stack_name)
     # Useful for debug
@@ -342,6 +343,10 @@ def cfn_create():
     try:
         stack = cfn.create(stack_name, cfn_config.process())
     except:
+        # cleanup ssl certificates if any
+        if 'ssl' in cfn_config.data:
+            print red("Deleting SSL certificates from stack")
+            iam.delete_ssl_certificate(cfn_config.ssl(), stack_name)
         import traceback
         abort(red("Failed to create: {error}".format(error=traceback.format_exc())))
 


### PR DESCRIPTION
If cfn_create fails and certificates had been uploaded, they are not deleted.
This change adds code to remove the certificates when cfn_create raises an exception.
Additional details: ministryofjustice/bootstrap-cfn/issues/112
Fixes ministryofjustice/bootstrap-cfn/issues/112.

Change details:
-  Updated CHANGELOG.md
-  Added new print statement to log certificates-related activity
-  Added code to delete SSL when cfn_create fails

Tests:
Run 1, before change:

```
(CBO) ✔ ~/Desktop/workspace/MOJ/crime-billing-online-deploy [ssl-cipherlist-test|●1✚ 1…1]
15:09 $ aws --profile cbo iam list-server-certificates
{
    "ServerCertificateMetadataList": []
}
(CBO) ✔ ~/Desktop/workspace/MOJ/crime-billing-online-deploy [ssl-cipherlist-test|●1✚ 1…1]
15:10 $ fab application:crimebillingonline aws:cbo environment:opstest1 config:./cloudformation/crimebillingonline.yaml passwords:./cloudformation/crimebillingonline-secrets.yaml cfn_create
INFO:root:IAM::upload_certificate: Uploading certificate 'opstest1-cert'..

Fatal error: Failed to create:

Aborting.
Failed to create:
(CBO) ✘-1 ~/Desktop/workspace/MOJ/crime-billing-online-deploy [ssl-cipherlist-test|●1✚ 1…1]
15:10 $ aws --profile cbo iam list-server-certificates
{
    "ServerCertificateMetadataList": [
        {
            "ServerCertificateId": "ASCAIM7AFS7CMEIARYJGC",
            "ServerCertificateName": "opstest1-cert-crimebillingonline-opstest1-9d583c6a",
            "Expiration": "2015-06-27T23:59:59Z",
            "Path": "/",
            "Arn": "arn:aws:iam::016649511486:server-certificate/opstest1-cert-crimebillingonline-opstest1-9d583c6a",
            "UploadDate": "2015-06-15T14:10:06Z"
        }
    ]
}
```

Run 2, after change:

```
(CBO) ✘-1 ~/Desktop/workspace/MOJ/crime-billing-online-deploy [ssl-cipherlist-test|●1✚ 1…1]
15:11 $ aws --profile cbo iam list-server-certificates
{
    "ServerCertificateMetadataList": []
}
(CBO) ✔ ~/Desktop/workspace/MOJ/crime-billing-online-deploy [ssl-cipherlist-test|●1✚ 1…1]
15:11 $ fab application:crimebillingonline aws:cbo environment:opstest1 config:./cloudformation/crimebillingonline.yaml passwords:./cloudformation/crimebillingonline-secrets.yaml cfn_create
Uploading SSL certificates to stack
INFO:root:IAM::upload_certificate: Uploading certificate 'opstest1-cert'..
Deleting SSL certificates from stack
INFO:root:IAM::get_remote_certificate: Found certificate 'opstest1-cert-crimebillingonline-opstest1-73baf60e'..
INFO:root:IAM::delete_certificate: Deleting certificate 'opstest1-cert'..

Fatal error: Failed to create: Traceback (most recent call last):
  File "/Users/benedettologiudice/.virtualenvs/CBO/lib/python2.7/site-packages/bootstrap_cfn/fab_tasks.py", line 344, in cfn_create
    stack = cfn.create(stack_name, cfn_config.process())
  File "/Users/benedettologiudice/.virtualenvs/CBO/lib/python2.7/site-packages/bootstrap_cfn/config.py", line 95, in process
    inc = json.load(open(inc_path))
IOError: [Errno 2] No such file or directory: './cloudformation/s3-bucket-policy-opstest1.json'


Aborting.
Failed to create: Traceback (most recent call last):
  File "/Users/benedettologiudice/.virtualenvs/CBO/lib/python2.7/site-packages/bootstrap_cfn/fab_tasks.py", line 344, in cfn_create
    stack = cfn.create(stack_name, cfn_config.process())
  File "/Users/benedettologiudice/.virtualenvs/CBO/lib/python2.7/site-packages/bootstrap_cfn/config.py", line 95, in process
    inc = json.load(open(inc_path))
IOError: [Errno 2] No such file or directory: './cloudformation/s3-bucket-policy-opstest1.json'

(CBO) ✘-1 ~/Desktop/workspace/MOJ/crime-billing-online-deploy [ssl-cipherlist-test|●1✚ 1…1]
15:11 $ aws --profile cbo iam list-server-certificates
{
    "ServerCertificateMetadataList": []
}
```
