### PR TITLE
Troposphere round #2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ boto==2.36.0
 mock==1.0.1
 testfixtures==4.1.2
 paramiko
+troposphere>=1.0.0

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2,6 +2,18 @@
 
 import unittest
 from bootstrap_cfn.config import ProjectConfig, ConfigParser
+from troposphere import awsencode, Ref
+from troposphere import iam, s3, rds, ec2
+from troposphere import Base64, FindInMap, GetAtt, GetAZs, Join
+from troposphere.autoscaling import AutoScalingGroup, Tag
+from troposphere.ec2 import SecurityGroup
+from troposphere.autoscaling import LaunchConfiguration
+
+from troposphere.route53 import RecordSetGroup
+from troposphere.elasticloadbalancing import LoadBalancer, HealthCheck,\
+    ConnectionDrainingPolicy
+from troposphere.iam import PolicyType
+
 import bootstrap_cfn.errors as errors
 from testfixtures import compare
 import json
@@ -43,71 +55,92 @@ class TestConfigParser(unittest.TestCase):
     def setUp(self):
         self.maxDiff = 9000
 
+    def _resources_to_dict(self, resources):
+        return json.loads(json.dumps(
+            dict((r.title, r) for r in resources),
+            cls=awsencode)
+        )
+
     def test_iam(self):
-        known = {'RolePolicies': {'Type': 'AWS::IAM::Policy',
-                                  'Properties': {'PolicyName': 'BaseHost',
-                                                 'PolicyDocument': {'Statement': [{'Action': ['autoscaling:Describe*'],
-                                                                                   'Resource': '*',
-                                                                                   'Effect': 'Allow'},
-                                                                                  {'Action': ['ec2:Describe*'],
-                                                                                   'Resource': '*',
-                                                                                   'Effect': 'Allow'},
-                                                                                  {'Action': ['rds:Describe*'],
-                                                                                   'Resource': '*',
-                                                                                   'Effect': 'Allow'},
-                                                                                  {'Action': ['elasticloadbalancing:Describe*'],
-                                                                                   'Resource': '*',
-                                                                                   'Effect': 'Allow'},
-                                                                                  {'Action': ['elasticache:Describe*'],
-                                                                                   'Resource': '*',
-                                                                                   'Effect': 'Allow'},
-                                                                                  {'Action': ['cloudformation:Describe*'],
-                                                                                   'Resource': '*',
-                                                                                   'Effect': 'Allow'},
-                                                                                  {'Action': ['s3:List*'],
-                                                                                   'Resource': '*',
-                                                                                   'Effect': 'Allow'}]},
-                                                 'Roles': [{'Ref': 'BaseHostRole'}]}},
-                 'InstanceProfile': {'Type': 'AWS::IAM::InstanceProfile',
-                                     'Properties': {'Path': '/',
-                                                    'Roles': [{'Ref': 'BaseHostRole'}]}},
-                 'BaseHostRole': {'Type': 'AWS::IAM::Role',
-                                  'Properties': {'Path': '/',
-                                                 'AssumeRolePolicyDocument': {'Statement': [{'Action': ['sts:AssumeRole'],
-                                                                                             'Effect': 'Allow',
-                                                                                             'Principal': {'Service': ['ec2.amazonaws.com']}}]}}}}
+        basehost_role = iam.Role('BaseHostRole')
+        basehost_role.Path = '/'
+        basehost_role.AssumeRolePolicyDocument = {
+            'Statement': [{'Action': ['sts:AssumeRole'],
+                           'Effect': 'Allow',
+                           'Principal': {'Service': ['ec2.amazonaws.com']}}
+                          ]
+        }
+        basehost_role_ref = iam.Ref(basehost_role)
+
+        role_policy = iam.PolicyType('RolePolicies')
+        role_policy.PolicyName = 'BaseHost'
+        role_policy.PolicyDocument = {
+            'Statement': [
+                {'Action': ['autoscaling:Describe*'],
+                 'Resource': '*',
+                 'Effect': 'Allow'},
+                {'Action': ['ec2:Describe*'],
+                 'Resource': '*',
+                 'Effect': 'Allow'},
+                {'Action': ['rds:Describe*'],
+                 'Resource': '*',
+                 'Effect': 'Allow'},
+                {'Action': ['elasticloadbalancing:Describe*'],
+                 'Resource': '*',
+                 'Effect': 'Allow'},
+                {'Action': ['elasticache:Describe*'],
+                 'Resource': '*',
+                 'Effect': 'Allow'},
+                {'Action': ['cloudformation:Describe*'],
+                 'Resource': '*',
+                 'Effect': 'Allow'},
+                {'Action': ['s3:List*'],
+                 'Resource': '*',
+                 'Effect': 'Allow'}]
+        }
+        role_policy.Roles = [basehost_role_ref]
+
+        instance_profile = iam.InstanceProfile('InstanceProfile')
+        instance_profile.Path = '/'
+        instance_profile.Roles = [basehost_role_ref]
+
         config = ConfigParser(None, 'my-stack-name')
-        compare(known, config.iam())
+        known = [role_policy, instance_profile, basehost_role]
+        known = self._resources_to_dict(known)
+        iam_dict = self._resources_to_dict(config.iam())
+        compare(known, iam_dict)
 
     def test_s3(self):
-        known = {
-            'StaticBucketPolicy': {
-                'Type': 'AWS::S3::BucketPolicy',
-                'Properties': {
-                    'PolicyDocument': {
-                        'Statement': [
-                            {
-                                'Action': [
-                                    's3:Get*',
-                                    's3:Put*',
-                                    's3:List*'],
-                                'Resource': 'arn:aws:s3:::moj-test-dev-static/*',
-                                'Effect': 'Allow',
-                                'Principal': {
-                                    'AWS': '*'}}]},
-                    'Bucket': {
-                        'Ref': 'StaticBucket'}}},
-            'StaticBucket': {
-                'Type': 'AWS::S3::Bucket',
-                'Properties': {
-                    'AccessControl': 'BucketOwnerFullControl',
-                    'BucketName': 'moj-test-dev-static'}}}
+        bucket = s3.Bucket('StaticBucket')
+        bucket.AccessControl = 'BucketOwnerFullControl'
+        bucket.BucketName = 'moj-test-dev-static'
+        bucket_ref = Ref(bucket)
+
+        static_bp = s3.BucketPolicy('StaticBucketPolicy')
+        static_bp.PolicyDocument = {
+            'Statement': [
+                {
+                    'Action': [
+                        's3:Get*',
+                        's3:Put*',
+                        's3:List*'],
+                    'Resource': 'arn:aws:s3:::moj-test-dev-static/*',
+                    'Effect': 'Allow',
+                    'Principal': {
+                        'AWS': '*'
+                    }
+                }
+            ]
+        }
+        static_bp.Bucket = bucket_ref
+
         config = ConfigParser(
             ProjectConfig(
                 'tests/sample-project.yaml',
                 'dev').config,
             'my-stack-name')
-        compare(known, config.s3())
+        compare(self._resources_to_dict([static_bp, bucket]),
+                self._resources_to_dict(config.s3()))
 
     def test_custom_s3_policy(self):
         expected_s3 = [
@@ -130,220 +163,218 @@ class TestConfigParser(unittest.TestCase):
             'policy': 'tests/sample-custom-s3-policy.json'}
 
         config = ConfigParser(project_config.config, 'my-stack-name')
-        s3_cfg = config.s3()
+        s3_cfg = self._resources_to_dict(config.s3())
         s3_custom_cfg = s3_cfg['StaticBucketPolicy'][
             'Properties']['PolicyDocument']['Statement']
 
         compare(expected_s3, s3_custom_cfg)
 
     def test_rds(self):
-        known = {
-            'DatabaseSG': {
-                'Type': 'AWS::EC2::SecurityGroup',
-                'Properties': {
-                    'VpcId': {'Ref': 'VPC'},
-                    'GroupDescription': 'SG for EC2 Access to RDS',
-                    'SecurityGroupIngress': [
-                        {
-                            'CidrIp': {'Fn::FindInMap': ['SubnetConfig', 'VPC', 'CIDR']},
-                            'IpProtocol': 'tcp',
-                            'FromPort': 5432,
-                            'ToPort': 5432
-                        },
-                        {
-                            'CidrIp': {'Fn::FindInMap': ['SubnetConfig', 'VPC', 'CIDR']},
-                            'IpProtocol': 'tcp',
-                            'FromPort': 3306,
-                            'ToPort': 3306
-                        }
-                    ]
-                }
-            },
-            'RDSInstance': {
-                'DependsOn': 'DatabaseSG',
-                'Type': 'AWS::RDS::DBInstance',
-                'Properties': {
-                    'AllocatedStorage': 5,
-                    'AllowMajorVersionUpgrade': 'false',
-                    'AutoMinorVersionUpgrade': 'false',
-                    'BackupRetentionPeriod': 1,
-                    'DBInstanceClass': 'db.t2.micro',
-                    'DBInstanceIdentifier': 'test-dev',
-                    'DBName': 'test',
-                    'VPCSecurityGroups': [{'Fn::GetAtt': ['DatabaseSG', 'GroupId']}],
-                    'DBSubnetGroupName': {'Ref': 'RDSSubnetGroup'},
-                    'Engine': 'postgres',
-                    'EngineVersion': '9.3.5',
-                    'MasterUserPassword': 'testpassword',
-                    'MasterUsername': 'testuser',
-                    'MultiAZ': 'false',
-                    'PubliclyAccessible': 'false',
-                    'StorageEncrypted': 'false',
-                    'StorageType': 'gp2'
-                }
-            },
-            'RDSSubnetGroup': {
-                'Properties': {
-                    'DBSubnetGroupDescription': 'VPC Subnets', 'SubnetIds': [
-                        {
-                            'Ref': 'SubnetA'
-                        },
-                        {
-                            'Ref': 'SubnetB'
-                        },
-                        {
-                            'Ref': 'SubnetC'
-                        }
-                    ]
-                },
-                'Type': 'AWS::RDS::DBSubnetGroup'
-            }
-        }
+        db_sg = ec2.SecurityGroup('DatabaseSG')
+        db_sg.VpcId = Ref('VPC')
+        db_sg.GroupDescription = 'SG for EC2 Access to RDS'
+        db_sg.SecurityGroupIngress = [
+            {"ToPort": 5432,
+             "FromPort": 5432,
+             "IpProtocol": "tcp",
+             "CidrIp": FindInMap("SubnetConfig", "VPC", "CIDR")},
+            {"ToPort": 3306,
+             "FromPort": 3306,
+             "IpProtocol": "tcp",
+             "CidrIp": FindInMap("SubnetConfig", "VPC", "CIDR")}
+        ]
+
+        db_subnet = rds.DBSubnetGroup('RDSSubnetGroup')
+        db_subnet.SubnetIds = [Ref('SubnetA'), Ref('SubnetB'), Ref('SubnetC')]
+        db_subnet.DBSubnetGroupDescription = 'VPC Subnets'
+
+        db_instance = rds.DBInstance('RDSInstance', DependsOn=db_sg.title)
+        db_instance.MultiAZ = False
+        db_instance.MasterUsername = 'testuser'
+        db_instance.MasterUserPassword = 'testpassword'
+        db_instance.DBName = 'test'
+        db_instance.PubliclyAccessible = False
+        db_instance.StorageEncrypted = False
+        db_instance.StorageType = 'gp2'
+        db_instance.AllocatedStorage = 5
+        db_instance.AllowMajorVersionUpgrade = False
+        db_instance.AutoMinorVersionUpgrade = False
+        db_instance.BackupRetentionPeriod = 1
+        db_instance.DBInstanceClass = 'db.t2.micro'
+        db_instance.DBInstanceIdentifier = 'test-dev'
+        db_instance.Engine = 'postgres'
+        db_instance.EngineVersion = '9.3.5'
+        db_instance.VPCSecurityGroups = [GetAtt(db_sg, 'GroupId')]
+        db_instance.DBSubnetGroupName = Ref(db_subnet)
+
+        known = [db_instance, db_subnet, db_sg]
 
         config = ConfigParser(
             ProjectConfig(
                 'tests/sample-project.yaml',
                 'dev',
                 'tests/sample-project-passwords.yaml').config, 'my-stack-name')
-        compare(known, config.rds())
+        rds_dict = self._resources_to_dict(config.rds())
+        known = self._resources_to_dict(known)
+        compare(known, rds_dict)
 
     def test_elb(self):
+        known = []
+        lb = LoadBalancer(
+            "ELBtestdevinternal",
+            ConnectionDrainingPolicy=ConnectionDrainingPolicy(
+                Enabled=True,
+                Timeout=120,
+            ),
+            Subnets=[Ref("SubnetA"), Ref("SubnetB"), Ref("SubnetC")],
+            Listeners=[
+                {
+                    "InstancePort": 80,
+                    "LoadBalancerPort": 80,
+                    "Protocol": "TCP"
+                }
+            ],
+            SecurityGroups=[Ref("DefaultSGtestdevinternal")],
+            LoadBalancerName="ELB-test-dev-internal",
+            Scheme="internal",
+        )
 
-        expected_resources = [
-            {'ELBtestdevexternal': {
-                u'Properties': {
-                    u'Listeners': [
-                        {'InstancePort': 80,
-                         'LoadBalancerPort': 80,
-                         'Protocol': 'TCP'},
-                        {'InstancePort': 443,
-                         'LoadBalancerPort': 443,
-                         'Protocol': 'TCP'}
-                    ],
-                    u'LoadBalancerName': 'ELB-test-dev-external',
-                    u'SecurityGroups': [{u'Ref': u'DefaultSGtestdevexternal'}],
-                    u'Scheme': 'internet-facing',
-                    u'ConnectionDrainingPolicy': {u'Enabled': True, u'Timeout': 120},
-                    u'Subnets': [
-                        {u'Ref': u'SubnetA'},
-                        {u'Ref': u'SubnetB'},
-                        {u'Ref': u'SubnetC'}
-                    ],
-                },
-                u'Type': u'AWS::ElasticLoadBalancing::LoadBalancer'}},
-            {'DNStestdevexternal': {
-                u'Properties': {
-                    u'Comment': u'Zone apex alias targeted to ElasticLoadBalancer.',
-                    u'HostedZoneName': 'kyrtest.pf.dsd.io.',
-                    u'RecordSets': [
-                        {u'AliasTarget': {
-                            u'DNSName': {u'Fn::GetAtt': ['ELBtestdevexternal', 'DNSName']},
-                            u'HostedZoneId': {u'Fn::GetAtt': ['ELBtestdevexternal', 'CanonicalHostedZoneNameID']}},
-                            u'Name': 'test-dev-external.kyrtest.pf.dsd.io.',
-                            u'Type': u'A'}
-                    ]
-                },
-                u'Type': u'AWS::Route53::RecordSetGroup'}},
-            {'Policytestdevexternal': {
-                u'Properties': {
-                    u'PolicyDocument': {
-                        u'Statement': [{
-                            u'Action': [u'elasticloadbalancing:DeregisterInstancesFromLoadBalancer',
-                                        u'elasticloadbalancing:RegisterInstancesWithLoadBalancer'],
-                            u'Effect': u'Allow',
-                            u'Resource': [{u'Fn::Join': [u'',
-                                                         [u'arn:aws:elasticloadbalancing:',
-                                                          {u'Ref': u'AWS::Region'},
-                                                          u':',
-                                                          {u'Ref': u'AWS::AccountId'},
-                                                          ':loadbalancer/ELB-test-dev-external']]}]}]},
-                    u'PolicyName': 'testdevexternalBaseHost',
-                    u'Roles': [{u'Ref': u'BaseHostRole'}]},
-                u'Type': u'AWS::IAM::Policy'}},
-            {'ELBtestdevinternal': {
-                u'Properties': {
-                    u'Listeners': [
-                        {'InstancePort': 80,
-                         'LoadBalancerPort': 80,
-                         'Protocol': 'TCP'}
-                    ],
-                    u'LoadBalancerName': 'ELB-test-dev-internal',
-                    u'SecurityGroups': [{u'Ref': u'DefaultSGtestdevinternal'}],
-                    u'ConnectionDrainingPolicy': {u'Enabled': True, u'Timeout': 120},
-                    u'Scheme': 'internal',
-                    u'Subnets': [
-                        {u'Ref': u'SubnetA'},
-                        {u'Ref': u'SubnetB'},
-                        {u'Ref': u'SubnetC'}
-                    ]
-                },
-                u'Type': u'AWS::ElasticLoadBalancing::LoadBalancer'}},
-            {'DNStestdevinternal': {
-                u'Properties': {
-                    u'Comment': u'Zone apex alias targeted to ElasticLoadBalancer.',
-                    u'HostedZoneName': 'kyrtest.pf.dsd.io.',
-                    u'RecordSets': [
-                        {u'AliasTarget': {
-                            u'DNSName': {u'Fn::GetAtt': ['ELBtestdevinternal', 'DNSName']},
-                            u'HostedZoneId': {u'Fn::GetAtt': ['ELBtestdevinternal', 'CanonicalHostedZoneNameID']}},
-                            u'Name': 'test-dev-internal.kyrtest.pf.dsd.io.',
-                            u'Type': u'A'}
-                    ]
-                },
-                u'Type': u'AWS::Route53::RecordSetGroup'}},
-            {'Policytestdevinternal': {u'Properties': {
-                u'PolicyDocument': {
-                    u'Statement': [{
-                        u'Action': [u'elasticloadbalancing:DeregisterInstancesFromLoadBalancer',
-                                    u'elasticloadbalancing:RegisterInstancesWithLoadBalancer'],
-                        u'Effect': u'Allow',
-                        u'Resource': [{u'Fn::Join': [u'',
-                                                     [u'arn:aws:elasticloadbalancing:',
-                                                      {u'Ref': u'AWS::Region'},
-                                                      u':',
-                                                      {u'Ref': u'AWS::AccountId'},
-                                                      ':loadbalancer/ELB-test-dev-internal']]}]}]},
-                        u'PolicyName': 'testdevinternalBaseHost',
-                        u'Roles': [{u'Ref': u'BaseHostRole'}]},
-                u'Type': u'AWS::IAM::Policy'}}
-        ]
-
-        expected_sgs = {
-            'DefaultSGtestdevexternal': {
-                'Properties': {
-                    u'SecurityGroupIngress': [
-                        {'ToPort': 443,
-                         'IpProtocol': 'tcp',
-                         'CidrIp': '0.0.0.0/0',
-                         'FromPort': 443},
-                        {'ToPort': 80,
-                         'IpProtocol': 'tcp',
-                         'CidrIp': '0.0.0.0/0',
-                         'FromPort': 80}
-                    ],
-                    'VpcId': {'Ref': 'VPC'},
-                    'GroupDescription': 'DefaultELBSecurityGroup'
-                },
-                'Type': u'AWS::EC2::SecurityGroup',
+        pt1 = PolicyType(
+            "Policytestdevexternal",
+            PolicyName="testdevexternalBaseHost",
+            PolicyDocument={
+                "Statement": [
+                    {
+                        "Action":
+                            ["elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+                             "elasticloadbalancing:RegisterInstancesWithLoadBalancer"],
+                        "Resource": [
+                            Join(
+                                "", ["arn:aws:elasticloadbalancing:",
+                                     Ref("AWS::Region"), ":",
+                                     Ref("AWS::AccountId"),
+                                     ":loadbalancer/ELB-test-dev-external"]
+                            )],
+                        "Effect": "Allow"}
+                ]
             },
-            'DefaultSGtestdevinternal': {
-                'Properties': {
-                    u'SecurityGroupIngress': [
-                        {'ToPort': 443,
-                         'IpProtocol': 'tcp',
-                         'CidrIp': '0.0.0.0/0',
-                         'FromPort': 443},
-                        {'ToPort': 80,
-                         'IpProtocol': 'tcp',
-                         'CidrIp': '0.0.0.0/0',
-                         'FromPort': 80}
-                    ],
-                    'VpcId': {'Ref': 'VPC'},
-                    'GroupDescription': 'DefaultELBSecurityGroup'
-                },
-                'Type': 'AWS::EC2::SecurityGroup',
-            }
-        }
+            Roles=[Ref("BaseHostRole")],
+        )
+
+        pt2 = PolicyType(
+            "Policytestdevinternal",
+            PolicyName="testdevinternalBaseHost",
+            PolicyDocument={
+                "Statement": [
+                    {
+                        "Action":
+                            ["elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+                             "elasticloadbalancing:RegisterInstancesWithLoadBalancer"],
+                        "Resource":
+                            [
+                                Join("", ["arn:aws:elasticloadbalancing:",
+                                          Ref("AWS::Region"), ":",
+                                          Ref("AWS::AccountId"),
+                                          ":loadbalancer/ELB-test-dev-internal"]
+                                     )
+                            ],
+                        "Effect": "Allow"
+                    }
+                ]
+            },
+            Roles=[Ref("BaseHostRole")],
+        )
+
+        rs = RecordSetGroup(
+            "DNStestdevexternal",
+            Comment="Zone apex alias targeted to ElasticLoadBalancer.",
+            HostedZoneName="kyrtest.pf.dsd.io.",
+            RecordSets=[
+                {
+                    "Type": "A",
+                    "AliasTarget": {
+                        "HostedZoneId": GetAtt("ELBtestdevexternal",
+                                               "CanonicalHostedZoneNameID"),
+                        "DNSName": GetAtt("ELBtestdevexternal", "DNSName")
+                    },
+                    "Name": "test-dev-external.kyrtest.pf.dsd.io."
+                }
+            ],
+        )
+
+        rsg = RecordSetGroup(
+            "DNStestdevinternal",
+            Comment="Zone apex alias targeted to ElasticLoadBalancer.",
+            HostedZoneName="kyrtest.pf.dsd.io.",
+            RecordSets=[
+                {
+                    "Type": "A",
+                    "AliasTarget": {
+                        "HostedZoneId":
+                            GetAtt(lb, "CanonicalHostedZoneNameID"),
+                        "DNSName": GetAtt(lb, "DNSName")
+                    },
+                    "Name": "test-dev-internal.kyrtest.pf.dsd.io."
+                }
+            ],
+        )
+
+        lb2 = LoadBalancer(
+            "ELBtestdevexternal",
+            ConnectionDrainingPolicy=ConnectionDrainingPolicy(
+                Enabled=True,
+                Timeout=120,
+            ),
+            Subnets=[Ref("SubnetA"), Ref("SubnetB"), Ref("SubnetC")],
+            Listeners=[
+                {"InstancePort": 80,
+                 "LoadBalancerPort": 80,
+                 "Protocol": "TCP"},
+                {"InstancePort": 443,
+                 "LoadBalancerPort": 443,
+                 "Protocol": "TCP"}
+            ],
+            SecurityGroups=[Ref("DefaultSGtestdevexternal")],
+            LoadBalancerName="ELB-test-dev-external",
+            Scheme="internet-facing",
+        )
+        known = [lb, lb2, pt1, pt2, rs, rsg]
+        expected_sgs = [
+            SecurityGroup(
+                "DefaultSGtestdevexternal",
+                SecurityGroupIngress=[
+                    {
+                        "ToPort": 443,
+                        "IpProtocol": "tcp",
+                        "FromPort": 443,
+                        "CidrIp": "0.0.0.0/0"
+                    },
+                    {"ToPort": 80,
+                     "IpProtocol": "tcp",
+                     "FromPort": 80,
+                     "CidrIp": "0.0.0.0/0"
+                     }
+                ],
+                VpcId=Ref("VPC"),
+                GroupDescription="DefaultELBSecurityGroup"),
+            SecurityGroup(
+                "DefaultSGtestdevinternal",
+                SecurityGroupIngress=[
+                    {"ToPort": 443,
+                     "IpProtocol": "tcp",
+                     "FromPort": 443,
+                     "CidrIp": "0.0.0.0/0"
+                     },
+                    {
+                        "ToPort": 80,
+                        "IpProtocol": "tcp",
+                        "FromPort": 80,
+                        "CidrIp": "0.0.0.0/0"
+                    }
+                ],
+                VpcId=Ref("VPC"),
+                GroupDescription="DefaultELBSecurityGroup",
+            )]
 
         config = ConfigParser(
             ProjectConfig(
@@ -351,9 +382,11 @@ class TestConfigParser(unittest.TestCase):
                 'dev').config, 'my-stack-name')
         elb_cfg, elb_sgs = config.elb()
 
-        compare(expected_resources, elb_cfg)
+        compare(self._resources_to_dict(known),
+                self._resources_to_dict(elb_cfg))
 
-        compare(expected_sgs, elb_sgs)
+        compare(self._resources_to_dict(expected_sgs),
+                self._resources_to_dict(elb_sgs))
 
     def test_elb_custom_sg(self):
 
@@ -396,12 +429,13 @@ class TestConfigParser(unittest.TestCase):
         }]
 
         config = ConfigParser(project_config.config, 'my-stack-name')
-        elb_cfg, elb_sgs = config.elb()
+        elb_cfg,  elb_sgs = config.elb()
+        elb_dict = self._resources_to_dict(elb_cfg)
+        sgs_dict = self._resources_to_dict(elb_sgs)
+        compare(expected_sgs, sgs_dict)
 
-        compare(expected_sgs, elb_sgs)
-
-        [elb] = (e.values()[0] for e in elb_cfg if 'ELBtestdevexternal' in e)
-        compare(elb['Properties']['SecurityGroups'],
+        # elb = [e.values()[0] for e in elb_dict if 'ELBtestdevexternal' in e]
+        compare(elb_dict['ELBtestdevexternal']['Properties']['SecurityGroups'],
                 [{u'Ref': u'SGName'}])
 
     def test_cf_includes(self):
@@ -595,50 +629,66 @@ class TestConfigParser(unittest.TestCase):
     def test_elb_with_ssl(self):
 
         self.maxDiff = None
+        DNSdockerregistryservice = RecordSetGroup(
+            "DNSdockerregistryservice",
+            Comment="Zone apex alias targeted to ElasticLoadBalancer.",
+            HostedZoneName="kyrtest.foo.bar.",
+            RecordSets=[
+                {"Type": "A",
+                 "AliasTarget": {
+                     "HostedZoneId": GetAtt("ELBdockerregistryservice",
+                                            "CanonicalHostedZoneNameID"),
+                     "DNSName": GetAtt("ELBdockerregistryservice", "DNSName")
+                 },
+                 "Name": "docker-registry.service.kyrtest.foo.bar."
+                 }
+            ],
+        )
 
-        known = [
-            {'ELBdockerregistryservice': {'Properties': {'Listeners': [{'InstancePort': 80,
-                                                                        'LoadBalancerPort': 80,
-                                                                        'Protocol': 'TCP'},
-                                                                       {'InstancePort': 443,
-                                                                           'LoadBalancerPort': 443,
-                                                                           'Protocol': 'HTTPS',
-                                                                           'SSLCertificateId': {'Fn::Join': ['',
-                                                                                                             ['arn:aws:iam::',
-                                                                                                              {'Ref': 'AWS::AccountId'},
-                                                                                                              ':server-certificate/',
-                                                                                                              'my-cert-my-stack-name']]}}],
-                                                         'LoadBalancerName': 'ELB-docker-registryservice',
-                                                         'SecurityGroups': [{'Ref': 'DefaultSGdockerregistryservice'}],
-                                                         u'ConnectionDrainingPolicy': {u'Enabled': True, u'Timeout': 120},
-                                                         'Scheme': 'internet-facing',
-                                                         'Subnets': [{'Ref': 'SubnetA'},
-                                                                     {'Ref': 'SubnetB'},
-                                                                     {'Ref': 'SubnetC'}]},
-                                          'Type': 'AWS::ElasticLoadBalancing::LoadBalancer'}},
-            {'DNSdockerregistryservice': {'Properties': {'Comment': 'Zone apex alias targeted to ElasticLoadBalancer.',
-                                                         'HostedZoneName': 'kyrtest.foo.bar.',
-                                                         'RecordSets': [{'AliasTarget': {'DNSName': {'Fn::GetAtt': ['ELBdockerregistryservice',
-                                                                                                                    'DNSName']},
-                                                                                         'HostedZoneId': {'Fn::GetAtt': ['ELBdockerregistryservice',
-                                                                                                                         'CanonicalHostedZoneNameID']}},
-                                                                           'Name': 'docker-registry.service.kyrtest.foo.bar.',
-                                                                         'Type': 'A'}]},
-                                          'Type': 'AWS::Route53::RecordSetGroup'}},
-            {'Policydockerregistryservice': {
-                u'Properties': {u'PolicyDocument': {u'Statement': [{u'Action': [u'elasticloadbalancing:DeregisterInstancesFromLoadBalancer',
-                                                                                u'elasticloadbalancing:RegisterInstancesWithLoadBalancer'],
-                                                                    u'Effect': u'Allow',
-                                                                    u'Resource': [{u'Fn::Join': [u'',
-                                                                                                 [u'arn:aws:elasticloadbalancing:',
-                                                                                                  {u'Ref': u'AWS::Region'},
-                                                                                                  u':',
-                                                                                                  {u'Ref': u'AWS::AccountId'},
-                                                                                                  ':loadbalancer/ELB-docker-registryservice']]}]}]},
-                                u'PolicyName': 'dockerregistryserviceBaseHost',
-                                u'Roles': [{u'Ref': u'BaseHostRole'}]},
-                u'Type': u'AWS::IAM::Policy'}}
-        ]
+        ELBdockerregistryservice = LoadBalancer(
+            "ELBdockerregistryservice",
+            ConnectionDrainingPolicy=ConnectionDrainingPolicy(
+                Enabled=True,
+                Timeout=120,
+            ),
+            Subnets=[Ref("SubnetA"), Ref("SubnetB"), Ref("SubnetC")],
+            Listeners=[
+                {"InstancePort": 80, "LoadBalancerPort": 80, "Protocol": "TCP"},
+                {"InstancePort": 443, "SSLCertificateId": Join(
+                    "", ["arn:aws:iam::", Ref("AWS::AccountId"),
+                         ":server-certificate/", "my-cert-my-stack-name"]),
+                 "LoadBalancerPort": 443, "Protocol": "HTTPS"}],
+            SecurityGroups=[Ref("DefaultSGdockerregistryservice")],
+            LoadBalancerName="ELB-docker-registryservice",
+            Scheme="internet-facing",
+        )
+
+        Policydockerregistryservice = PolicyType(
+            "Policydockerregistryservice",
+            PolicyName="dockerregistryserviceBaseHost",
+            PolicyDocument={
+                "Statement": [
+                    {
+                        "Action": [
+                            "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+                            "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
+                        ],
+                        "Resource": [
+                            Join("", ["arn:aws:elasticloadbalancing:",
+                                      Ref("AWS::Region"), ":",
+                                      Ref("AWS::AccountId"),
+                                      ":loadbalancer/ELB-docker-registryservice"
+                                      ]
+                                 )
+                        ],
+                        "Effect": "Allow"
+                    }
+                ]
+            },
+            Roles=[Ref("BaseHostRole")],
+        )
+        known = [DNSdockerregistryservice, ELBdockerregistryservice,
+                 Policydockerregistryservice]
 
         project_config = ProjectConfig('tests/sample-project.yaml', 'dev')
         # Ugh. Fixtures please?
@@ -659,122 +709,176 @@ class TestConfigParser(unittest.TestCase):
             ],
         }]
         config = ConfigParser(project_config.config, 'my-stack-name')
-        elb_cfg, elb_sgs = config.elb()
-        compare(known, elb_cfg)
+        elb_cfg, _ = config.elb()
+        # elb_dict = json.loads(json.dumps([{r.title: r} for r in elb_cfg ],
+        #                                  cls=awsencode))
+        compare(self._resources_to_dict(known),
+                self._resources_to_dict(elb_cfg))
 
     def test_elb_with_healthcheck(self):
         self.maxDiff = None
-        known = [
-            {'ELBdockerregistryservice': {'Properties': {'Listeners': [{'InstancePort': 80,
-                                                                        'LoadBalancerPort': 80,
-                                                                        'Protocol': 'TCP'},
-                                                                       {'InstancePort': 443,
-                                                                           'LoadBalancerPort': 443,
-                                                                           'Protocol': 'TCP'}],
-                                                         'LoadBalancerName': 'ELB-docker-registryservice',
-                                                         'SecurityGroups': [{'Ref': 'DefaultSGdockerregistryservice'}],
-                                                         u'ConnectionDrainingPolicy': {u'Enabled': True, u'Timeout': 120},
-                                                         'HealthCheck': {
-                                                             'HealthyThreshold': 10,
-                                                             'Interval': 2,
-                                                             'Target': 'HTTPS:80/blah',
-                                                             'Timeout': 5,
-                                                             'UnhealthyThreshold': 2},
-                                                         'Scheme': 'internet-facing',
-                                                         'Subnets': [{'Ref': 'SubnetA'},
-                                                                     {'Ref': 'SubnetB'},
-                                                                     {'Ref': 'SubnetC'}]},
-                                          'Type': 'AWS::ElasticLoadBalancing::LoadBalancer'}},
-            {'DNSdockerregistryservice': {'Properties': {'Comment': 'Zone apex alias targeted to ElasticLoadBalancer.',
-                                                         'HostedZoneName': 'kyrtest.foo.bar.',
-                                                         'RecordSets': [{'AliasTarget': {'DNSName': {'Fn::GetAtt': ['ELBdockerregistryservice',
-                                                                                                                    'DNSName']},
-                                                                                         'HostedZoneId': {'Fn::GetAtt': ['ELBdockerregistryservice',
-                                                                                                                         'CanonicalHostedZoneNameID']}},
-                                                                           'Name': 'docker-registry.service.kyrtest.foo.bar.',
-                                                                         'Type': 'A'}]},
-                                          'Type':
-                                          'AWS::Route53::RecordSetGroup'}},
-            {'Policydockerregistryservice': {u'Properties': {u'PolicyDocument': {
-                u'Statement': [{u'Action': [u'elasticloadbalancing:DeregisterInstancesFromLoadBalancer',
-                                            u'elasticloadbalancing:RegisterInstancesWithLoadBalancer'],
-                                u'Effect': u'Allow',
-                                u'Resource': [{u'Fn::Join': [u'',
-                                                             [u'arn:aws:elasticloadbalancing:',
-                                                                 {u'Ref': u'AWS::Region'},
-                                                                 u':',
-                                                                 {u'Ref': u'AWS::AccountId'},
-                                                                 ':loadbalancer/ELB-docker-registryservice']]}]}]},
-                u'PolicyName': 'dockerregistryserviceBaseHost',
-                u'Roles': [{u'Ref': u'BaseHostRole'}]},
-                u'Type': u'AWS::IAM::Policy'}}
-        ]
-        project_config = ProjectConfig('tests/sample-project.yaml', 'dev')
-        project_config.config['elb'] = [{
-            'name': 'docker-registry.service',
-            'hosted_zone': 'kyrtest.foo.bar.',
-            'scheme': 'internet-facing',
-            'listeners': [
-                {'LoadBalancerPort': 80,
-                 'InstancePort': 80,
-                 'Protocol': 'TCP'
-                 },
-                {'LoadBalancerPort': 443,
-                 'InstancePort': 443,
-                 'Protocol': 'TCP'
-                 },
+
+        DNSdockerregistryservice = RecordSetGroup(
+            "DNSdockerregistryservice",
+            Comment="Zone apex alias targeted to ElasticLoadBalancer.",
+            HostedZoneName="kyrtest.foo.bar.",
+            RecordSets=[
+                {
+                    "Type": "A",
+                    "AliasTarget": {
+                        "HostedZoneId": GetAtt("ELBdockerregistryservice",
+                                               "CanonicalHostedZoneNameID"),
+                        "DNSName": GetAtt("ELBdockerregistryservice", "DNSName")
+                    },
+                    "Name": "docker-registry.service.kyrtest.foo.bar."
+                }
             ],
-            'health_check': {
-                'HealthyThreshold': 10,
-                'Interval': 2,
-                'Target': 'HTTPS:80/blah',
-                'Timeout': 5,
-                'UnhealthyThreshold': 2
+        )
+
+        ELBdockerregistryservice = LoadBalancer(
+            "ELBdockerregistryservice",
+            ConnectionDrainingPolicy=ConnectionDrainingPolicy(
+                Enabled=True,
+                Timeout=120,
+            ),
+            Subnets=[Ref("SubnetA"), Ref("SubnetB"), Ref("SubnetC")],
+            HealthCheck=HealthCheck(
+                HealthyThreshold=10,
+                Interval=2,
+                Target="HTTPS:80/blah",
+                Timeout=5,
+                UnhealthyThreshold=2,
+            ),
+            Listeners=[{"InstancePort": 80,
+                        "LoadBalancerPort": 80,
+                        "Protocol": "TCP"},
+                       {"InstancePort": 443,
+                        "LoadBalancerPort": 443,
+                        "Protocol": "TCP"}
+                       ],
+            SecurityGroups=[Ref("DefaultSGdockerregistryservice")],
+            LoadBalancerName="ELB-docker-registryservice",
+            Scheme="internet-facing",
+        )
+
+        Policydockerregistryservice = PolicyType(
+            "Policydockerregistryservice",
+            PolicyName="dockerregistryserviceBaseHost",
+            PolicyDocument={
+                "Statement": [
+                    {
+                        "Action":
+                            ["elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+                             "elasticloadbalancing:RegisterInstancesWithLoadBalancer"],
+                        "Resource": [
+                            Join("", ["arn:aws:elasticloadbalancing:",
+                                      Ref("AWS::Region"), ":",
+                                      Ref("AWS::AccountId"),
+                                      ":loadbalancer/ELB-docker-registryservice"]
+                                 )],
+                        "Effect": "Allow"
+                    }
+                ]
+
+            },
+            Roles=[Ref("BaseHostRole")],
+        )
+        project_config = ProjectConfig('tests/sample-project.yaml', 'dev')
+        project_config.config['elb'] = [
+            {
+                'name': 'docker-registry.service',
+                'hosted_zone': 'kyrtest.foo.bar.',
+                'scheme': 'internet-facing',
+                'listeners': [
+                    {'LoadBalancerPort': 80,
+                     'InstancePort': 80,
+                     'Protocol': 'TCP'
+                     },
+                    {'LoadBalancerPort': 443,
+                     'InstancePort': 443,
+                     'Protocol': 'TCP'
+                     },
+                    ],
+                'health_check': {
+                    'HealthyThreshold': 10,
+                    'Interval': 2,
+                    'Target': 'HTTPS:80/blah',
+                    'Timeout': 5,
+                    'UnhealthyThreshold': 2
+                }
             }
-        }]
+        ]
         config = ConfigParser(project_config.config, 'my-stack-name')
-        elb_cfg, elb_sgs = config.elb()
-        compare(elb_cfg, known)
+        elb_cfg, _ = config.elb()
+        known = [DNSdockerregistryservice, ELBdockerregistryservice,
+                 Policydockerregistryservice]
+        compare(self._resources_to_dict(known),
+                self._resources_to_dict(elb_cfg))
 
     def test_elb_with_reserved_chars(self):
-        known = [
-            {'ELBdevdockerregistryservice': {'Properties': {'Listeners': [{'InstancePort': 80,
-                                                                           'LoadBalancerPort': 80,
-                                                                           'Protocol': 'TCP'},
-                                                                          {'InstancePort': 443,
-                                                                           'LoadBalancerPort': 443,
-                                                                           'Protocol': 'TCP'}],
-                                                            'LoadBalancerName': 'ELB-dev_docker-registryservice',
-                                                            'SecurityGroups': [{'Ref': 'DefaultSGdevdockerregistryservice'}],
-                                                            'ConnectionDrainingPolicy': {u'Enabled': True, u'Timeout': 120},
-                                                            'Scheme': 'internet-facing',
-                                                            'Subnets': [{'Ref': 'SubnetA'},
-                                                                        {'Ref': 'SubnetB'},
-                                                                        {'Ref': 'SubnetC'}]},
-                                             'Type': 'AWS::ElasticLoadBalancing::LoadBalancer'}},
-            {'DNSdevdockerregistryservice': {'Properties': {'Comment': 'Zone apex alias targeted to ElasticLoadBalancer.',
-                                                            'HostedZoneName': 'kyrtest.foo.bar.',
-                                                            'RecordSets': [{'AliasTarget': {'DNSName': {'Fn::GetAtt': ['ELBdevdockerregistryservice',
-                                                                                                                       'DNSName']},
-                                                                                            'HostedZoneId': {'Fn::GetAtt': ['ELBdevdockerregistryservice',
-                                                                                                                            'CanonicalHostedZoneNameID']}},
-                                                                            'Name': 'dev_docker-registry.service.kyrtest.foo.bar.',
-                                                                            'Type': 'A'}]},
-                                             'Type': 'AWS::Route53::RecordSetGroup'}},
-            {'Policydevdockerregistryservice': {
-                u'Properties': {u'PolicyDocument': {u'Statement': [{u'Action': [u'elasticloadbalancing:DeregisterInstancesFromLoadBalancer',
-                                                                                u'elasticloadbalancing:RegisterInstancesWithLoadBalancer'],
-                                                                    u'Effect': u'Allow',
-                                                                    u'Resource': [{u'Fn::Join': [u'',
-                                                                                                 [u'arn:aws:elasticloadbalancing:',
-                                                                                                  {u'Ref': u'AWS::Region'},
-                                                                                                  u':',
-                                                                                                  {u'Ref': u'AWS::AccountId'},
-                                                                                                  ':loadbalancer/ELB-dev_docker-registryservice']]}]}]},
-                                u'PolicyName': 'devdockerregistryserviceBaseHost',
-                                u'Roles': [{u'Ref': u'BaseHostRole'}]},
-                u'Type': u'AWS::IAM::Policy'}}
-        ]
+        ELBdevdockerregistryservice = LoadBalancer(
+            "ELBdevdockerregistryservice",
+            ConnectionDrainingPolicy=ConnectionDrainingPolicy(
+                Enabled=True,
+                Timeout=120,
+            ),
+            Subnets=[Ref("SubnetA"), Ref("SubnetB"), Ref("SubnetC")],
+            Listeners=[
+                {"InstancePort": 80,
+                 "LoadBalancerPort": 80,
+                 "Protocol": "TCP"},
+                {"InstancePort": 443,
+                 "LoadBalancerPort": 443,
+                 "Protocol": "TCP"
+                 }
+            ],
+            SecurityGroups=[Ref("DefaultSGdevdockerregistryservice")],
+            LoadBalancerName="ELB-dev_docker-registryservice",
+            Scheme="internet-facing",
+        )
+
+        DNSdevdockerregistryservice = RecordSetGroup(
+            "DNSdevdockerregistryservice",
+            Comment="Zone apex alias targeted to ElasticLoadBalancer.",
+            HostedZoneName="kyrtest.foo.bar.",
+            RecordSets=[
+                {"Type": "A",
+                 "AliasTarget": {
+                     "HostedZoneId":
+                         GetAtt(ELBdevdockerregistryservice,
+                                "CanonicalHostedZoneNameID"),
+                     "DNSName": GetAtt(ELBdevdockerregistryservice,
+                                       "DNSName")
+                 },
+                 "Name": "dev_docker-registry.service.kyrtest.foo.bar."
+                 }
+            ],
+        )
+
+        Policydevdockerregistryservice = PolicyType(
+            "Policydevdockerregistryservice",
+            PolicyName="devdockerregistryserviceBaseHost",
+            PolicyDocument={
+                "Statement":
+                    [
+                        {
+                            "Action": [
+                                "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+                                "elasticloadbalancing:RegisterInstancesWithLoadBalancer"],
+                            "Resource": [
+                                Join("",
+                                     ["arn:aws:elasticloadbalancing:",
+                                      Ref("AWS::Region"), ":",
+                                      Ref("AWS::AccountId"),
+                                      ":loadbalancer/ELB-dev_docker-registryservice"]
+                                     )
+                            ],
+                            "Effect": "Allow"
+                        }
+                    ]
+            },
+            Roles=[Ref("BaseHostRole")],
+        )
 
         project_config = ProjectConfig('tests/sample-project.yaml', 'dev')
         # Ugh. Fixtures please?
@@ -794,79 +898,102 @@ class TestConfigParser(unittest.TestCase):
             ],
         }]
         config = ConfigParser(project_config.config, 'my-stack-name')
-        elb_cfg, elb_sgs = config.elb()
-        compare(known, elb_cfg)
+        elb_cfg, _ = config.elb()
+        known = [DNSdevdockerregistryservice, ELBdevdockerregistryservice,
+                 Policydevdockerregistryservice]
+        compare(self._resources_to_dict(known),
+                self._resources_to_dict(elb_cfg))
 
     def test_ec2(self):
 
         self.maxDiff = None
 
-        known = {
-            'BaseHostLaunchConfig': {'Properties': {'AssociatePublicIpAddress': 'true',
-                                                    'BlockDeviceMappings': [{'DeviceName': '/dev/sda1',
-                                                                             'Ebs': {'VolumeSize': 10}},
-                                                                            {'DeviceName': '/dev/sdf',
-                                                                             'Ebs': {'VolumeSize': 10}}],
-                                                    'IamInstanceProfile': {'Ref': 'InstanceProfile'},
-                                                    'ImageId': {'Fn::FindInMap': ['AWSRegion2AMI',
-                                                                                  {'Ref': 'AWS::Region'},
-                                                                                  'AMI']},
-                                                    'InstanceType': 't2.micro',
-                                                    'KeyName': 'default',
-                                                    'SecurityGroups': [{'Ref': 'BaseHostSG'}, {'Ref': 'AnotherSG'}],
-                                                    'UserData': {'Fn::Base64': {'Fn::Join': ['',
-                                                                                             ['#!/bin/bash -xe\n',
-                                                                                              '#do nothing for now']]}}},
-                                     'Type': 'AWS::AutoScaling::LaunchConfiguration'},
-            'BaseHostSG': {'Properties': {'GroupDescription': 'BaseHost Security Group',
-                                          'SecurityGroupIngress': [{'CidrIp': '0.0.0.0/0',
-                                                                    'FromPort': 22,
-                                                                    'IpProtocol': 'tcp',
-                                                                    'ToPort': 22},
-                                                                   {'CidrIp': '0.0.0.0/0',
-                                                                    'FromPort': 80,
-                                                                    'IpProtocol': 'tcp',
-                                                                    'ToPort': 80}],
-                                          'VpcId': {'Ref': 'VPC'}},
-                           'Type': 'AWS::EC2::SecurityGroup'},
-            'AnotherSG': {'Properties': {'GroupDescription': 'BaseHost Security Group',
-                                         'SecurityGroupIngress': [{'SourceSecurityGroupName': {'Ref': 'BaseHostSG'},
-                                                                   'FromPort': 443,
-                                                                   'IpProtocol': 'tcp',
-                                                                   'ToPort': 443}],
-                                         'VpcId': {'Ref': 'VPC'}},
-                          'Type': 'AWS::EC2::SecurityGroup'},
-            'ScalingGroup': {'Properties': {'AvailabilityZones': {'Fn::GetAZs': ''},
-                                            'DesiredCapacity': 1,
-                                            'LaunchConfigurationName': {'Ref': 'BaseHostLaunchConfig'},
-                                            'MaxSize': 3,
-                                            'MinSize': 0,
-                                            'Tags': [{'Key': 'Role',
-                                                      'PropagateAtLaunch': True,
-                                                      'Value': 'docker'},
-                                                     {'Key': 'Apps',
-                                                      'PropagateAtLaunch': True,
-                                                      'Value': 'test'},
-                                                     {'Key': 'Env',
-                                                      'PropagateAtLaunch': True,
-                                                      'Value': 'dev'}],
-                                            'VPCZoneIdentifier': [{'Ref': 'SubnetA'},
-                                                                  {'Ref': 'SubnetB'},
-                                                                  {'Ref': 'SubnetC'}]},
-                             'Type': 'AWS::AutoScaling::AutoScalingGroup'}
-        }
+        tags = [
+            ('Role', 'docker'),
+            ('Apps', 'test'),
+            ('Env', 'dev'),
+            ]
+        ScalingGroup = AutoScalingGroup(
+            "ScalingGroup",
+            DesiredCapacity=1,
+            Tags=[Tag(k, v, True) for (k, v) in tags],
+            MinSize=0,
+            MaxSize=3,
+            VPCZoneIdentifier=[Ref("SubnetA"), Ref("SubnetB"), Ref("SubnetC")],
+            LaunchConfigurationName=Ref("BaseHostLaunchConfig"),
+            AvailabilityZones=GetAZs(""),
+        )
 
+        BaseHostSG = SecurityGroup(
+            "BaseHostSG",
+            SecurityGroupIngress=[
+                {
+                    "ToPort": 22,
+                    "FromPort": 22,
+                    "IpProtocol": "tcp",
+                    "CidrIp": "0.0.0.0/0"
+                },
+                {
+                    "ToPort": 80,
+                    "FromPort": 80,
+                    "IpProtocol": "tcp",
+                    "CidrIp": "0.0.0.0/0"
+                }
+            ],
+            VpcId=Ref("VPC"),
+            GroupDescription="BaseHost Security Group",
+        )
+
+        BaseHostLaunchConfig = LaunchConfiguration(
+            "BaseHostLaunchConfig",
+            UserData=Base64(Join("", ["#!/bin/bash -xe\n", "#do nothing for now"])),
+            ImageId=FindInMap("AWSRegion2AMI", Ref("AWS::Region"), "AMI"),
+            BlockDeviceMappings=[
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {"VolumeSize": 10}
+                },
+                {
+                    "DeviceName": "/dev/sdf",
+                    "Ebs": {"VolumeSize": 10}
+                }
+            ],
+            KeyName="default",
+            SecurityGroups=[Ref(BaseHostSG), Ref("AnotherSG")],
+            IamInstanceProfile=Ref("InstanceProfile"),
+            InstanceType="t2.micro",
+            AssociatePublicIpAddress="true",
+        )
+
+        AnotherSG = SecurityGroup(
+            "AnotherSG",
+            SecurityGroupIngress=[
+                {
+                    "ToPort": 443,
+                    "FromPort": 443,
+                    "SourceSecurityGroupName": Ref(BaseHostSG),
+                    "IpProtocol": "tcp"
+                }
+            ],
+            VpcId=Ref("VPC"),
+            GroupDescription="BaseHost Security Group",
+        )
+        known = [AnotherSG, BaseHostLaunchConfig, BaseHostSG, ScalingGroup]
         config = ConfigParser(
             ProjectConfig(
                 'tests/sample-project.yaml',
                 'dev').config, 'my-stack-name')
-        compare(known, config.ec2())
+        ec2_json = self._resources_to_dict(config.ec2())
+        # compare(, ec2_json)
+
+        compare(self._resources_to_dict(known), ec2_json)
 
     def test_ec2_with_no_block_device_specified(self):
         project_config = ProjectConfig('tests/sample-project.yaml', 'dev')
         project_config.config['ec2'].pop('block_devices')
         config = ConfigParser(project_config.config, 'my-stack-name')
-        config_output = config.ec2()['BaseHostLaunchConfig'][
+        ec2_dict = self._resources_to_dict(config.ec2())
+        config_output = ec2_dict['BaseHostLaunchConfig'][
             'Properties']['BlockDeviceMappings']
         known = [{'DeviceName': '/dev/sda1', 'Ebs': {'VolumeSize': 20}}]
         self.assertEquals(known, config_output)


### PR DESCRIPTION
Change code and tests to use troposphere objects and only convert to
json before sending data to AWS.
