### PR TITLE
Automatic tagging of cloudformation and resources  with environment name

### DIFF
--- a/bootstrap_cfn/cloudformation.py
+++ b/bootstrap_cfn/cloudformation.py
@@ -17,10 +17,11 @@ class Cloudformation:
         self.aws_region_name = aws_region_name
         self.conn_cfn = utils.connect_to_aws(boto.cloudformation, self)
 
-    def create(self, stack_name, template_body):
+    def create(self, stack_name, template_body, tags):
         stack = self.conn_cfn.create_stack(stack_name=stack_name,
                                            template_body=template_body,
-                                           capabilities=['CAPABILITY_IAM'])
+                                           capabilities=['CAPABILITY_IAM'],
+                                           tags=tags)
         return stack
 
     def delete(self, stack_name):

--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -344,7 +344,7 @@ def cfn_create(test=False):
     # print cfn_config.process()
     # Inject security groups in stack template and create stacks.
     try:
-        stack = cfn.create(stack_name, cfn_config.process())
+        stack = cfn.create(stack_name, cfn_config.process(), tags=get_cloudformation_tags())
     except:
         # cleanup ssl certificates if any
         if 'ssl' in cfn_config.data:
@@ -408,3 +408,14 @@ def update_certs():
     else:
         logging.error("No certificates updated so skipping "
                       "ELB certificate update...")
+
+
+def get_cloudformation_tags():
+    """
+    Get a top-level set of tags for the stack, these will propagate
+    down so that many of the created resources will be tagged in
+    addition. Notable omissions are EBS volumes and route53 resources
+    """
+    return {
+        "Env": env.environment,
+    }

--- a/tests/test.py
+++ b/tests/test.py
@@ -81,10 +81,16 @@ class CfnTestCase(unittest.TestCase):
         mock_config = {'create_stack.return_value': self.stack_name}
         cf_connect_result.configure_mock(**mock_config)
         boto.cloudformation.connect_to_region = cf_mock
-
+        test_tags = {'Env': 'Dev', 'MiscTag': 'misc'}
         cf = cloudformation.Cloudformation(self.env.aws_profile)
-        x = cf.create(self.stack_name, '{}')
+        x = cf.create(self.stack_name, '{}', test_tags)
 
+        # Check we called create with the right values
+        cf_connect_result.create_stack.assert_called_once_with(
+            template_body='{}',
+            stack_name=self.stack_name,
+            capabilities=['CAPABILITY_IAM'],
+            tags=test_tags)
         self.assertEqual(x, self.stack_name)
 
     def test_cf_delete(self):


### PR DESCRIPTION
By passing tags while creating our cloudformation stack we can
propagate these tags to our created resources, enabling easy
separation of environments for billing purposes
