### PR TITLE
Deprecate ec2.tags.Env and warn about its use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+##Unreleased
+* Deprecate the ec2.tags.Env tag and warn about its use
+
 ## Version 0.5.3 [WIP]
 * Improve message content when cfn_create raises an exception and fails.
 * Cleanup SSL certificates when cfn_create raises an exception and fails.

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -911,7 +911,6 @@ class TestConfigParser(unittest.TestCase):
         tags = [
             ('Role', 'docker'),
             ('Apps', 'test'),
-            ('Env', 'dev'),
             ]
         ScalingGroup = AutoScalingGroup(
             "ScalingGroup",


### PR DESCRIPTION
The Env tag is now deprecated for specifying the environment on the
command line. This change will ensure we ignore it and warn about
its use. ~~(closes ministryofjustice/template-deploy # 51)~~
