### PR TITLE
Make S3 permissions tighter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Version 0.5.3 [WIP]
 * Improve message content when cfn_create raises an exception and fails.
 * Cleanup SSL certificates when cfn_create raises an exception and fails.
+* Make default S3 permissions more restrictive. Everyone can get object.
 
 ## Version 0.5.2
 

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -277,14 +277,10 @@ class ConfigParser:
         else:
             arn = 'arn:aws:s3:::%s/*' % self.data['s3']['static-bucket-name']
             policy = {
-                'Action': [
-                    's3:Get*',
-                    's3:Put*',
-                    's3:List*'],
+                'Action': ['s3:GetObject'],
                 'Resource': arn,
                 'Effect': 'Allow',
-                'Principal': {
-                    'AWS': '*'}}
+                'Principal': '*'}
 
         bucket_policy = BucketPolicy(
             "StaticBucketPolicy",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -121,14 +121,10 @@ class TestConfigParser(unittest.TestCase):
             'Statement': [
                 {
                     'Action': [
-                        's3:Get*',
-                        's3:Put*',
-                        's3:List*'],
+                        's3:GetObject'],
                     'Resource': 'arn:aws:s3:::moj-test-dev-static/*',
                     'Effect': 'Allow',
-                    'Principal': {
-                        'AWS': '*'
-                    }
+                    'Principal': '*'
                 }
             ]
         }


### PR DESCRIPTION
Give everyone s3:GetObject but otherwise leave access to the bucket locked down. If you use template deploy as directed the jenkins box will also get write permissions. Otherwise you can still overwrite the policy by including custom json.

Tested this by building a new stack and uploading assets from my own account. Everything worked fine.
