### PR TITLE
Allow security groups in YAML to reference themselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## Version 0.5.x
+
 * Add an SSL cipher list policy pindown: implicitly (no YAML entry needed)
   or explicitly (with YAML entry)
+* Allow security groups in YAML to reference themselves (for example an
+  "elasticsearch" SG that allows other instances of that sg (and itself) to
+  access port 9300)
+
 ## Version 0.5.3
 
 * Improve message content when cfn_create raises an exception and fails.

--- a/docs/sample-project.yaml
+++ b/docs/sample-project.yaml
@@ -27,14 +27,16 @@ dev:
           FromPort: 22
           ToPort: 22
           CidrIp: 0.0.0.0/0
+        # Allow the ELB defined below test-dev-external
         - IpProtocol: tcp
           FromPort: 80
           ToPort: 80
-          CidrIp: 0.0.0.0/0
+          SourceSecurityGroupId: { Ref: DefaultSGtestdevexternal }
+        # Allow all other members of the BaseSG to speak to us on 4505 and 4506
         - IpProtocol: tcp
           FromPort: 4505
           ToPort: 4506
-          CidrIp: 10.0.0.0/16
+          SourceSecurityGroupId: { Ref: BaseSG }
   elb:
     - name: test-dev-external
       hosted_zone: integration.dsd.io.


### PR DESCRIPTION
This means you can create a security group that allows access to (say)
port 9300 to other members of the same security group.

Prime example of this is Elasticsearch where anyone in the ES sg should
be able to speak to every other instance in the SG to form a cluster
