### PR TITLE
Sort imports lines consistently and remove unused imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 language: python
 
 install:
-  - pip install coveralls flake8
+  - pip install coveralls flake8 git+git://github.com/public/flake8-import-order@2ac7052#egg=flake8-import-order
 
 python:
   - "2.7"
@@ -26,4 +26,4 @@ script:
 
 after_success:
   coveralls
-  
+

--- a/bootstrap_cfn/cloudformation.py
+++ b/bootstrap_cfn/cloudformation.py
@@ -1,10 +1,8 @@
-import sys
 import boto.cloudformation
 import boto.ec2
-from boto.ec2 import autoscale
-from boto.exception import NoAuthHandlerFound
-from boto.provider import ProfileNotFoundError
+
 from bootstrap_cfn import utils
+
 
 class Cloudformation:
 

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -1,23 +1,25 @@
 import json
+import logging
 import os
 import sys
+
+
+from troposphere import Base64, FindInMap, GetAZs, GetAtt, Join, Output, Ref, Tags, Template
+from troposphere.autoscaling import AutoScalingGroup, BlockDeviceMapping, \
+    EBSBlockDevice, LaunchConfiguration, Tag
+from troposphere.ec2 import InternetGateway, Route, RouteTable, SecurityGroup, \
+    SecurityGroupIngress, Subnet, SubnetRouteTableAssociation, VPC, \
+    VPCGatewayAttachment
+from troposphere.elasticloadbalancing import ConnectionDrainingPolicy, \
+    HealthCheck, LoadBalancer, Policy
+from troposphere.iam import InstanceProfile, PolicyType, Role
+from troposphere.rds import DBInstance, DBSubnetGroup
+from troposphere.route53 import AliasTarget, RecordSet, RecordSetGroup
+from troposphere.s3 import Bucket, BucketPolicy
+
 import yaml
-import logging
 
-from troposphere import Ref, Join, GetAtt, Tags
-from troposphere import FindInMap, GetAZs, Base64, Output
-from troposphere.autoscaling import LaunchConfiguration, \
-    AutoScalingGroup, BlockDeviceMapping, EBSBlockDevice, Tag
-from troposphere.elasticloadbalancing import LoadBalancer, HealthCheck, \
-    ConnectionDrainingPolicy, Policy
-from troposphere.ec2 import SecurityGroup, SecurityGroupIngress
-from troposphere.route53 import RecordSetGroup, RecordSet, AliasTarget
-from troposphere.ec2 import Route, Subnet, InternetGateway, VPC, \
-    VPCGatewayAttachment, SubnetRouteTableAssociation, RouteTable
-from troposphere.iam import Role, PolicyType, InstanceProfile
-
-import bootstrap_cfn.errors as errors
-import bootstrap_cfn.utils as utils
+from bootstrap_cfn import errors, utils
 
 
 class ProjectConfig:
@@ -93,7 +95,6 @@ class ConfigParser:
             template, sort_keys=True, indent=4, separators=(',', ': '))
 
     def base_template(self):
-        from troposphere import Template
 
         t = Template()
 
@@ -268,9 +269,6 @@ class ConfigParser:
                 print "\n\n[ERROR] Missing S3 fields [%s]" % i
                 sys.exit(1)
 
-        from troposphere import Ref, awsencode
-        from troposphere.s3 import Bucket, BucketPolicy
-
         bucket = Bucket(
             "StaticBucket",
             AccessControl="BucketOwnerFullControl",
@@ -321,9 +319,6 @@ class ConfigParser:
         }
 
         # LOAD STACK TEMPLATE
-        from troposphere import Ref, FindInMap, GetAtt, awsencode
-        from troposphere.rds import DBInstance, DBSubnetGroup
-        from troposphere.ec2 import SecurityGroup
         resources = []
         rds_subnet_group = DBSubnetGroup(
             "RDSSubnetGroup",

--- a/bootstrap_cfn/ec2.py
+++ b/bootstrap_cfn/ec2.py
@@ -1,7 +1,4 @@
-import sys
 import boto.ec2
-from boto.exception import NoAuthHandlerFound
-from boto.provider import ProfileNotFoundError
 
 from bootstrap_cfn import cloudformation
 from bootstrap_cfn import utils

--- a/bootstrap_cfn/elb.py
+++ b/bootstrap_cfn/elb.py
@@ -1,9 +1,8 @@
-import sys
 import logging
+
 import boto.ec2.elb
-from bootstrap_cfn import cloudformation
-from bootstrap_cfn import iam
-from bootstrap_cfn import utils
+
+from bootstrap_cfn import cloudformation, iam, utils
 from bootstrap_cfn.errors import CloudResourceNotFoundError
 
 

--- a/bootstrap_cfn/errors.py
+++ b/bootstrap_cfn/errors.py
@@ -4,24 +4,29 @@ class BootstrapCfnError(Exception):
     def __init__(self, msg):
         print >> sys.stderr,  "[ERROR] {0}: {1}".format(self.__class__.__name__, msg)
 
+
 class CfnConfigError(BootstrapCfnError):
     pass
+
 
 class CfnTimeoutError(BootstrapCfnError):
     pass
 
+
 class NoCredentialsError(BootstrapCfnError):
     def __init__(self):
-        super(NoCredentialsErrror, self).__init__(
+        super(NoCredentialsError, self).__init__(
             "Create an ~/.aws/credentials file by following this layout:\n\n" +
             "  http://boto.readthedocs.org/en/latest/boto_config_tut.html#credentials"
         )
+
 
 class ProfileNotFoundError(BootstrapCfnError):
     def __init__(self, profile_name):
         super(ProfileNotFoundError, self).__init__(
             "'{0}' not found in ~/.aws/credentials".format(profile_name)
         )
+
 
 class CloudResourceNotFoundError(BootstrapCfnError):
     pass

--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -1,22 +1,23 @@
 #!/usr/bin/env python
 
+import logging
 import os
 import sys
 import time
-import logging
+import uuid
+
+from boto.route53.exception import DNSServerError
 
 from fabric.api import env, task
-from fabric.utils import abort
 from fabric.colors import green, red
+from fabric.utils import abort
 
-from bootstrap_cfn.config import ProjectConfig, ConfigParser
 from bootstrap_cfn.cloudformation import Cloudformation
-from bootstrap_cfn.iam import IAM
+from bootstrap_cfn.config import ConfigParser, ProjectConfig
 from bootstrap_cfn.elb import ELB
+from bootstrap_cfn.iam import IAM
 from bootstrap_cfn.r53 import R53
 from bootstrap_cfn.utils import tail
-from boto.route53.exception import DNSServerError
-import uuid
 
 
 # Default fab config. Set via the tasks below or --set

--- a/bootstrap_cfn/iam.py
+++ b/bootstrap_cfn/iam.py
@@ -1,7 +1,9 @@
-import boto.iam
-from boto.connection import AWSQueryConnection
-from bootstrap_cfn import utils
 import logging
+
+from boto.connection import AWSQueryConnection
+import boto.iam
+
+from bootstrap_cfn import utils
 from bootstrap_cfn.errors import CloudResourceNotFoundError
 
 

--- a/bootstrap_cfn/r53.py
+++ b/bootstrap_cfn/r53.py
@@ -1,5 +1,6 @@
 import boto.route53
-import utils
+
+from bootstrap_cfn import utils
 
 
 class R53:

--- a/bootstrap_cfn/utils.py
+++ b/bootstrap_cfn/utils.py
@@ -1,12 +1,13 @@
+import os
+import time
+
+from copy import deepcopy
+
 import boto.exception
 import boto.provider
 import boto.sts
-import sys
-import time
-import os
 
 import bootstrap_cfn.errors as errors
-from copy import deepcopy
 
 
 def timeout(timeout, interval):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name='bootstrap_cfn',

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,15 +1,16 @@
+import os
 import tempfile
 import unittest
-import mock
-import yaml
+
 import boto.cloudformation
 import boto.ec2.autoscale
-import paramiko
-from bootstrap_cfn import cloudformation
-from bootstrap_cfn import ec2
-from bootstrap_cfn import iam
-from bootstrap_cfn import errors
-import os
+
+import mock
+
+import yaml
+
+from bootstrap_cfn import cloudformation, errors, iam
+
 
 class CfnTestCase(unittest.TestCase):
 

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -1,0 +1,10 @@
+import unittest
+
+from bootstrap_cfn import ec2  # noqa
+
+
+class TestEC2(unittest.TestCase):
+
+    def test_loaded(self):
+        # Not a great test, but it at least checks for syntax erros in the file
+        pass

--- a/tests/test_elb.py
+++ b/tests/test_elb.py
@@ -1,0 +1,10 @@
+import unittest
+
+from bootstrap_cfn import elb  # noqa
+
+
+class TestELB(unittest.TestCase):
+
+    def test_loaded(self):
+        # Not a great test, but it at least checks for syntax erros in the file
+        pass

--- a/tests/test_fab_tasks.py
+++ b/tests/test_fab_tasks.py
@@ -1,0 +1,10 @@
+import unittest
+
+from bootstrap_cfn import fab_tasks  # noqa
+
+
+class TestFabTasks(unittest.TestCase):
+
+    def test_loaded(self):
+        # Not a great test, but it at least checks for syntax erros in the file
+        pass

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -1,9 +1,12 @@
-from bootstrap_cfn import iam
 import unittest
-from nose.tools import raises
+
 import boto
-from mock import Mock
-from mock import patch
+
+from mock import Mock, patch
+
+from nose.tools import raises
+
+from bootstrap_cfn import iam
 from bootstrap_cfn.errors import CloudResourceNotFoundError
 
 

--- a/tests/test_r53.py
+++ b/tests/test_r53.py
@@ -1,9 +1,12 @@
-from bootstrap_cfn import r53
-import unittest
-import tempfile
-import boto.route53
-import mock
 import os
+import tempfile
+import unittest
+
+import boto.route53
+
+import mock
+
+from bootstrap_cfn import r53
 
 
 class BootstrapCfnR53TestCase(unittest.TestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,22 +1,19 @@
 #!/usr/bin/env python
-
-import unittest
-from bootstrap_cfn.config import ProjectConfig, ConfigParser
-from troposphere import awsencode, Ref
-from troposphere import iam, s3, rds, ec2
-from troposphere import Base64, FindInMap, GetAtt, GetAZs, Join
-from troposphere.autoscaling import AutoScalingGroup, Tag
-from troposphere.ec2 import SecurityGroup, SecurityGroupIngress
-from troposphere.autoscaling import LaunchConfiguration
-
-from troposphere.route53 import RecordSetGroup
-from troposphere.elasticloadbalancing import LoadBalancer, HealthCheck,\
-    ConnectionDrainingPolicy, Policy
-from troposphere.iam import PolicyType
-
-import bootstrap_cfn.errors as errors
-from testfixtures import compare
 import json
+import unittest
+
+from testfixtures import compare
+
+from troposphere import Base64, FindInMap, GetAZs, GetAtt, Join, Ref, awsencode, ec2, iam, rds, s3
+from troposphere.autoscaling import AutoScalingGroup, LaunchConfiguration, Tag
+from troposphere.ec2 import SecurityGroup, SecurityGroupIngress
+from troposphere.elasticloadbalancing import ConnectionDrainingPolicy, HealthCheck, LoadBalancer, Policy
+from troposphere.iam import PolicyType
+from troposphere.route53 import RecordSetGroup
+
+
+from bootstrap_cfn import errors
+from bootstrap_cfn.config import ConfigParser, ProjectConfig
 
 
 class TestConfig(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,2 +1,4 @@
 [flake8]
 max-line-length=160
+application-import-names = bootstrap_cfn,tests
+import-order-style = cryptography


### PR DESCRIPTION
The order of lines is:
- imports stdlib
- imports from third party modules
- import from local (i.e. bootstrap-cfn) modules

And the things imported on each line should be ordered.

Uses https://github.com/public/flake8-import-order to ensure it is checked.
