### PR TITLE
Generate Userdata script to set hostname of instances based on format string

### DIFF
--- a/bootstrap_cfn/errors.py
+++ b/bootstrap_cfn/errors.py
@@ -1,7 +1,9 @@
 import sys
 
+
 class BootstrapCfnError(Exception):
     def __init__(self, msg):
+        super(BootstrapCfnError, self).__init__(msg)
         print >> sys.stderr,  "[ERROR] {0}: {1}".format(self.__class__.__name__, msg)
 
 
@@ -10,6 +12,10 @@ class CfnConfigError(BootstrapCfnError):
 
 
 class CfnTimeoutError(BootstrapCfnError):
+    pass
+
+
+class CfnHostnamePatternError(BootstrapCfnError):
     pass
 
 

--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -271,7 +271,7 @@ def get_config():
         env.environment,
         passwords=env.stack_passwords)
 
-    cfn_config = ConfigParser(project_config.config, get_stack_name())
+    cfn_config = ConfigParser(project_config.config, get_stack_name(), environment=env.environment, application=env.application)
     return cfn_config
 
 

--- a/bootstrap_cfn/mime_packer.py
+++ b/bootstrap_cfn/mime_packer.py
@@ -1,0 +1,80 @@
+import gzip
+
+from StringIO import StringIO
+from contextlib import closing
+from email import encoders
+from email.mime.base import MIMEBase
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+
+STARTS_WITH_MAPPINGS = {
+    '#include': 'text/x-include-url',
+    '#include-once': 'text/x-include-once-url',
+    '#!': 'text/x-shellscript',
+    '#cloud-config': 'text/cloud-config',
+    '#cloud-config-archive': 'text/cloud-config-archive',
+    '#upstart-job': 'text/upstart-job',
+    '#part-handler': 'text/part-handler',
+    '#cloud-boothook': 'text/cloud-boothook'
+}
+
+
+def try_decode(data):
+    try:
+        return (True, data.decode())
+    except UnicodeDecodeError:
+        return (False, data)
+
+
+def get_type(content, deftype):
+    rtype = deftype
+
+    (can_be_decoded, content) = try_decode(content)
+
+    if can_be_decoded:
+        # slist is sorted longest first
+        slist = sorted(list(STARTS_WITH_MAPPINGS.keys()), key=lambda e: 0 - len(e))
+        for sstr in slist:
+            if content.startswith(sstr):
+                rtype = STARTS_WITH_MAPPINGS[sstr]
+                break
+    else:
+        rtype = 'application/octet-stream'
+
+    return(rtype)
+
+
+def pack(parts, opts={}):
+    outer = MIMEMultipart()
+
+    for arg in parts:
+        if isinstance(arg, basestring):
+            arg = {'content': arg}
+
+        if 'mime_type' in arg:
+            mtype = arg['mime_type']
+        else:
+            mtype = get_type(arg['content'], opts.get('deftype', "text/plain"))
+
+        maintype, subtype = mtype.split('/', 1)
+        if maintype == 'text':
+            # Note: we should handle calculating the charset
+            msg = MIMEText(arg['content'], _subtype=subtype)
+        else:
+            msg = MIMEBase(maintype, subtype)
+            msg.set_payload(arg['content'])
+            # Encode the payload using Base64
+            encoders.encode_base64(msg)
+
+        outer.attach(msg)
+
+    with closing(StringIO()) as buff:
+        if opts.get('compress', False):
+            gfile = gzip.GzipFile(fileobj=buff)
+            gfile.write(outer.as_string().encode())
+            gfile.close()
+        else:
+            buff.write(outer.as_string().encode())
+
+        return buff.getvalue()

--- a/docs/sample-project.yaml
+++ b/docs/sample-project.yaml
@@ -12,7 +12,9 @@ dev:
     tags:
       Role: docker
       Apps: test
-      Env: dev
+    hostname_pattern: '{instance_id}.{tags[Role]}.{environment}.{application}'
+    cloud_config:
+      manage_etc_hosts: true
     parameters:
       KeyName: default
       InstanceType: t2.micro


### PR DESCRIPTION
i.e. If we set hostname_pattern to "{instance_id}.my_project" then we
drop a script in via userdata that [cloud-init](http://cloudinit.readthedocs.org/)
will instruct later phases of cloud-init to set the hostname. So that
sudo can resolve the hostname and and we don't get warnings/delays we
also want to be able to instruct cloud_config to manage /etc/hosts -
which we do via letting the user pass in a chunk of YAML for
[cloud_config](http://cloudinit.readthedocs.org/en/latest/topics/examples.html)

There are other types of userdata we could add to the Userdata "Mime
Multipart archive" but we don't need them right now so don't expose them
from the config YAML
