### PR TITLE
Use automatic resource naming for S3 buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+##UNRELEASED
+
+* Use a automatic resource naming to allow S3 bucket names to be auto named
+by AWS
+
 ## Version 0.5.4
 
 * Add an SSL cipher list policy pindown: implicitly (no YAML entry needed)

--- a/bootstrap_cfn/cloudformation.py
+++ b/bootstrap_cfn/cloudformation.py
@@ -58,11 +58,28 @@ class Cloudformation:
             load_balancers: Set of stack resources containing only
                 load balancers for this stack
         """
+        resource_type = 'AWS::ElasticLoadBalancing::LoadBalancer'
+        return self.get_resource_type(stack_name_or_id, resource_type)
+
+    def get_resource_type(self, stack_name_or_id, resource_type=None):
+        """
+        Collect up a set of specific stack resources
+
+        Args:
+            stack_name_or_id (string): Name or id used to identify the stack
+            resource_type(string): The resource type identifier
+
+        Returns:
+            resources: Set of stack resources containing only
+                the resource type for this stack
+        """
         # get the stack
-        load_balancers = []
+        resources = []
         stack = self.conn_cfn.describe_stacks(stack_name_or_id)
         if stack:
-            fn = lambda x: x.resource_type == 'AWS::ElasticLoadBalancing::LoadBalancer'
-            # get the load balancers group
-            load_balancers = filter(fn, stack[0].list_resources())
-        return load_balancers
+            resources = stack[0].list_resources()
+            if resource_type:
+                # get the resources
+                resources = filter(lambda x: x.resource_type == resource_type,
+                                   resources)
+        return resources

--- a/bootstrap_cfn/ec2.py
+++ b/bootstrap_cfn/ec2.py
@@ -3,6 +3,7 @@ import boto.ec2
 from bootstrap_cfn import cloudformation
 from bootstrap_cfn import utils
 
+
 class EC2:
 
     conn_cfn = None

--- a/bootstrap_cfn/elb.py
+++ b/bootstrap_cfn/elb.py
@@ -67,7 +67,7 @@ class ELB:
                         if protocol == "HTTPS":
                             logging.info("ELB::set_ssl_certificates: "
                                          "Found HTTPS protocol on '%s', "
-                                         "updating SSL certificate with '%s'" 
+                                         "updating SSL certificate with '%s'"
                                          % (load_balancer.name, cert_arn))
                             self.conn_elb.set_lb_listener_SSL_certificate(load_balancer.name,
                                                                           out_port,
@@ -83,4 +83,3 @@ class ELB:
                                                  "No load balancers found in stack,")
 
         return updated_load_balancers
-

--- a/bootstrap_cfn/errors.py
+++ b/bootstrap_cfn/errors.py
@@ -4,7 +4,7 @@ import sys
 class BootstrapCfnError(Exception):
     def __init__(self, msg):
         super(BootstrapCfnError, self).__init__(msg)
-        print >> sys.stderr,  "[ERROR] {0}: {1}".format(self.__class__.__name__, msg)
+        print >> sys.stderr, "[ERROR] {0}: {1}".format(self.__class__.__name__, msg)
 
 
 class CfnConfigError(BootstrapCfnError):

--- a/bootstrap_cfn/utils.py
+++ b/bootstrap_cfn/utils.py
@@ -78,7 +78,6 @@ def tail(stack, stack_name):
     from fabric.colors import green, red, yellow
     """Show and then tail the event log"""
 
-
     def colorize(e):
         if e.endswith("_IN_PROGRESS"):
             return yellow(e)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -8,7 +8,7 @@ from mock import patch
 
 from testfixtures import compare
 
-from troposphere import Base64, FindInMap, GetAZs, GetAtt, Join, Ref, awsencode, ec2, iam, rds, s3
+from troposphere import Base64, FindInMap, GetAZs, GetAtt, Join, Ref, Template, awsencode, ec2, iam, rds, s3
 from troposphere.autoscaling import AutoScalingGroup, LaunchConfiguration, Tag
 from troposphere.ec2 import SecurityGroup, SecurityGroupIngress
 from troposphere.elasticloadbalancing import ConnectionDrainingPolicy, HealthCheck, LoadBalancer, Policy
@@ -119,7 +119,7 @@ class TestConfigParser(unittest.TestCase):
         bucket_ref = Ref(bucket)
 
         static_bp = s3.BucketPolicy('StaticBucketPolicy')
-        resource_value = [Join("", ["arn:aws:s3:::", {"Ref": "StaticBucket"}, "/*"])]
+        resource_value = Join("", ["arn:aws:s3:::", {"Ref": "StaticBucket"}, "/*"])
 
         static_bp.PolicyDocument = {
             'Statement': [
@@ -139,8 +139,24 @@ class TestConfigParser(unittest.TestCase):
                 'tests/sample-project.yaml',
                 'dev').config,
             'my-stack-name')
+
+        # Create S3 resources in template
+        template = Template()
+        config.s3(template)
+        resources = template.resources.values()
+
         compare(self._resources_to_dict([static_bp, bucket]),
-                self._resources_to_dict(config.s3()))
+                self._resources_to_dict(resources))
+
+        # Test for outputs
+        expected_outputs = {
+            "StaticBucketName": {
+                "Description": "S3 bucket name",
+                "Value": {"Ref": "StaticBucket"}
+            }
+        }
+        actual_outputs = self._resources_to_dict(template.outputs.values())
+        compare(expected_outputs, actual_outputs)
 
     def test_s3_no_subkeys(self):
         """
@@ -151,7 +167,7 @@ class TestConfigParser(unittest.TestCase):
         bucket_ref = Ref(bucket)
 
         static_bp = s3.BucketPolicy('StaticBucketPolicy')
-        resource_value = [Join("", ["arn:aws:s3:::", {"Ref": "StaticBucket"}, "/*"])]
+        resource_value = Join("", ["arn:aws:s3:::", {"Ref": "StaticBucket"}, "/*"])
 
         static_bp.PolicyDocument = {
             'Statement': [
@@ -171,8 +187,22 @@ class TestConfigParser(unittest.TestCase):
         base_config.config["s3"] = None
         config = ConfigParser(base_config.config,
                               'my-stack-name')
+        # Create S3 resources in template
+        template = Template()
+        config.s3(template)
+        resources = template.resources.values()
+
         compare(self._resources_to_dict([static_bp, bucket]),
-                self._resources_to_dict(config.s3()))
+                self._resources_to_dict(resources))
+        # Test for outputs
+        expected_outputs = {
+            "StaticBucketName": {
+                "Description": "S3 bucket name",
+                "Value": {"Ref": "StaticBucket"}
+            }
+        }
+        actual_outputs = self._resources_to_dict(template.outputs.values())
+        compare(expected_outputs, actual_outputs)
 
     def test_custom_s3_policy(self):
         resource_value = 'arn:aws:s3:::moj-test-dev-static/*'
@@ -192,15 +222,31 @@ class TestConfigParser(unittest.TestCase):
         project_config = ProjectConfig('tests/sample-project.yaml', 'dev')
 
         project_config.config['s3'] = {
-            'StaticBucketName': 'moj-test-dev-static',
+            'static-bucket-name': 'moj-test-dev-static',
             'policy': 'tests/sample-custom-s3-policy.json'}
 
         config = ConfigParser(project_config.config, 'my-stack-name')
-        s3_cfg = self._resources_to_dict(config.s3())
+
+        # Create S3 resources in template
+        template = Template()
+        config.s3(template)
+        resources = template.resources.values()
+
+        s3_cfg = self._resources_to_dict(resources)
         s3_custom_cfg = s3_cfg['StaticBucketPolicy'][
             'Properties']['PolicyDocument']['Statement']
 
         compare(expected_s3, s3_custom_cfg)
+
+        # Test for outputs
+        expected_outputs = {
+            "StaticBucketName": {
+                "Description": "S3 bucket name",
+                "Value": {"Ref": "StaticBucket"}
+            }
+        }
+        actual_outputs = self._resources_to_dict(template.outputs.values())
+        compare(expected_outputs, actual_outputs)
 
     def test_rds(self):
         db_sg = ec2.SecurityGroup('DatabaseSG')
@@ -476,7 +522,7 @@ class TestConfigParser(unittest.TestCase):
         }]
 
         config = ConfigParser(project_config.config, 'my-stack-name')
-        elb_cfg,  elb_sgs = config.elb()
+        elb_cfg, elb_sgs = config.elb()
         elb_dict = self._resources_to_dict(elb_cfg)
         sgs_dict = self._resources_to_dict(elb_sgs)
         compare(expected_sgs, sgs_dict)
@@ -864,7 +910,7 @@ class TestConfigParser(unittest.TestCase):
                      'InstancePort': 443,
                      'Protocol': 'TCP'
                      },
-                    ],
+                ],
                 'health_check': {
                     'HealthyThreshold': 10,
                     'Interval': 2,
@@ -984,7 +1030,7 @@ class TestConfigParser(unittest.TestCase):
         tags = [
             ('Role', 'docker'),
             ('Apps', 'test'),
-            ]
+        ]
         ScalingGroup = AutoScalingGroup(
             "ScalingGroup",
             DesiredCapacity=1,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -119,12 +119,14 @@ class TestConfigParser(unittest.TestCase):
         bucket_ref = Ref(bucket)
 
         static_bp = s3.BucketPolicy('StaticBucketPolicy')
+        resource_value = [Join("", ["arn:aws:s3:::", {"Ref": "StaticBucket"}, "/*"])]
+
         static_bp.PolicyDocument = {
             'Statement': [
                 {
                     'Action': [
                         's3:GetObject'],
-                    'Resource': 'arn:aws:s3:::moj-test-dev-static/*',
+                    'Resource': resource_value,
                     'Effect': 'Allow',
                     'Principal': '*'
                 }
@@ -140,7 +142,40 @@ class TestConfigParser(unittest.TestCase):
         compare(self._resources_to_dict([static_bp, bucket]),
                 self._resources_to_dict(config.s3()))
 
+    def test_s3_no_subkeys(self):
+        """
+        Test that a config with the s3: key alone will load
+        """
+        bucket = s3.Bucket('StaticBucket')
+        bucket.AccessControl = 'BucketOwnerFullControl'
+        bucket_ref = Ref(bucket)
+
+        static_bp = s3.BucketPolicy('StaticBucketPolicy')
+        resource_value = [Join("", ["arn:aws:s3:::", {"Ref": "StaticBucket"}, "/*"])]
+
+        static_bp.PolicyDocument = {
+            'Statement': [
+                {
+                    'Action': [
+                        's3:GetObject'],
+                    'Resource': resource_value,
+                    'Effect': 'Allow',
+                    'Principal': '*'
+                }
+            ]
+        }
+        static_bp.Bucket = bucket_ref
+
+        # Load project config and wipe out all s3 subkeys
+        base_config = ProjectConfig('tests/sample-project.yaml', 'dev')
+        base_config.config["s3"] = None
+        config = ConfigParser(base_config.config,
+                              'my-stack-name')
+        compare(self._resources_to_dict([static_bp, bucket]),
+                self._resources_to_dict(config.s3()))
+
     def test_custom_s3_policy(self):
+        resource_value = 'arn:aws:s3:::moj-test-dev-static/*'
         expected_s3 = [
             {
                 'Action': [
@@ -148,16 +183,16 @@ class TestConfigParser(unittest.TestCase):
                     's3:Put*',
                     's3:List*',
                     's3:Delete*'],
-                'Resource': 'arn:aws:s3:::moj-test-dev-static/*',
-                            'Effect': 'Allow',
-                            'Principal': {'AWS': '*'}
+                'Resource': resource_value,
+                'Effect': 'Allow',
+                'Principal': {'AWS': '*'}
             }
         ]
 
         project_config = ProjectConfig('tests/sample-project.yaml', 'dev')
 
         project_config.config['s3'] = {
-            'static-bucket-name': 'moj-test-dev-static',
+            'StaticBucketName': 'moj-test-dev-static',
             'policy': 'tests/sample-custom-s3-policy.json'}
 
         config = ConfigParser(project_config.config, 'my-stack-name')
@@ -467,6 +502,10 @@ class TestConfigParser(unittest.TestCase):
             "someoutput": {
                 "Description": "For tests",
                 "Value": "BLAHBLAH"
+            },
+            "StaticBucketName": {
+                "Description": "S3 bucket name",
+                "Value": {"Ref": "StaticBucket"}
             }
         }
         config = ConfigParser(project_config.config, 'my-stack-name')
@@ -498,14 +537,14 @@ class TestConfigParser(unittest.TestCase):
             "RolePolicies", "ScalingGroup", "StaticBucket",
             "StaticBucketPolicy", "SubnetA", "SubnetB", "SubnetC",
             "SubnetRouteTableAssociationA", "SubnetRouteTableAssociationB",
-            "SubnetRouteTableAssociationC", "VPC"
+            "SubnetRouteTableAssociationC", "VPC",
         ]
 
         resource_names = cfn_template['Resources'].keys()
         resource_names.sort()
         compare(resource_names, wanted)
 
-        wanted = ["dbhost", "dbport"]
+        wanted = ["StaticBucketName", "dbhost", "dbport"]
         output_names = cfn_template['Outputs'].keys()
         output_names.sort()
         compare(output_names, wanted)
@@ -561,7 +600,7 @@ class TestConfigParser(unittest.TestCase):
         resource_names.sort()
         compare(resource_names, wanted)
 
-        wanted = ["dbhost", "dbport"]
+        wanted = ["StaticBucketName", "dbhost", "dbport"]
         output_names = cfn_template['Outputs'].keys()
         output_names.sort()
         compare(output_names, wanted)


### PR DESCRIPTION
Currently we use hard coded names for resources like S3. This change
will allow us to use dynamic names auto-generated by aws and exposed
as an output. (Closes ministryofjustice/bootstrap-cfn#123)
- S3 bucket names are optional in config, default to dynamic ones
- Add a method and fab_file function to allow getting a filtered
  list of resources
- Update tests to look for new BucketName output and policy changes
- PEP8 fixes
