### PR TITLE
Make config parser extensible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
-##UNRELEASED
-
-* Use a automatic resource naming to allow S3 bucket names to be auto named
-by AWS
+## Unreleased
+* Make it possible to override the ConfigParser so that sub-modules can update the CloudFormation config.
+* Use a automatic resource naming to allow S3 bucket names to be auto named by AWS
 
 ## Version 0.5.4
 

--- a/README.rst
+++ b/README.rst
@@ -304,6 +304,10 @@ If you wish to include some static cloudformation json and have it merged with t
 
 The tool will then perform a deep merge of the includes with the generated template dictionary. Any keys or subkeys in the template dictionary that clash will have their values **overwritten** by the included dictionary or recursively merged if the value is itself a dictionary.
 
+ConfigParser
+++++++++++++++
+If you want to include or modify cloudformation resources but need to include some logic and not a static include. You can subclass the ConfigParser and set the new class as `env.cloudformation_parser` in your fabfile.
+
 
 Enabling RDS encryption
 +++++++++++++++++++++++

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -43,7 +43,7 @@ class ProjectConfig:
             return yaml.load(open(fp).read())
 
 
-class ConfigParser:
+class ConfigParser(object):
 
     config = {}
 

--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -271,7 +271,8 @@ def get_config():
         env.environment,
         passwords=env.stack_passwords)
 
-    cfn_config = ConfigParser(project_config.config, get_stack_name(), environment=env.environment, application=env.application)
+    Parser = env.get('cloudformation_parser', ConfigParser)
+    cfn_config = Parser(project_config.config, get_stack_name(), environment=env.environment, application=env.application)
     return cfn_config
 
 


### PR DESCRIPTION
This makes it possible to subclass the config parser, override it's methods and then use this subclass when generating the CloudFormation json.

We need this so that bootstrap-salt can update the user data section of the launch configuration.
