### PR TITLE
Use automatic naming of the RDS

### DIFF
--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -3,7 +3,6 @@ import logging
 import os
 import sys
 import textwrap
-import uuid
 
 from troposphere import Base64, FindInMap, GetAZs, GetAtt, Join, Output, Ref, Tags, Template
 from troposphere.autoscaling import AutoScalingGroup, BlockDeviceMapping, \
@@ -335,6 +334,7 @@ class ConfigParser(object):
 
         optional_fields = {
             'storage-encrypted': 'StorageEncrypted',
+            'identifier': 'DBInstanceIdentifier'
         }
 
         # LOAD STACK TEMPLATE
@@ -363,10 +363,6 @@ class ConfigParser(object):
         )
         resources.append(database_sg)
 
-        identifier = ("RDS%s%s"
-                      % ((self.stack_name).replace('-', '').replace('.', '').replace('_', ''),
-                         uuid.uuid4().__str__()[-8:]))
-
         rds_instance = DBInstance(
             "RDSInstance",
             PubliclyAccessible=False,
@@ -374,7 +370,6 @@ class ConfigParser(object):
             AutoMinorVersionUpgrade=False,
             VPCSecurityGroups=[GetAtt(database_sg, "GroupId")],
             DBSubnetGroupName=Ref(rds_subnet_group),
-            DBInstanceIdentifier=identifier,
             StorageEncrypted=False,
             DependsOn=database_sg.title
         )

--- a/docs/sample-project.yaml
+++ b/docs/sample-project.yaml
@@ -62,7 +62,6 @@ dev:
     storage: 5
     storage-type: gp2
     backup-retention-period: 1
-    identifier: test-dev
     db-name: test
     db-master-username: testuser
     instance-class: db.t2.micro

--- a/tests/test.py
+++ b/tests/test.py
@@ -64,7 +64,6 @@ class CfnTestCase(unittest.TestCase):
                                   'db-master-password': 'testpassword',
                                   'db-master-username': 'testuser',
                                   'db-name': 'test',
-                                  'identifier': 'test-dev',
                                   'instance-class': 'db.t2.micro',
                                   'multi-az': False,
                                   'storage': 5,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -302,9 +302,10 @@ class TestConfigParser(unittest.TestCase):
         self.assertTrue("DBInstanceIdentifier" in rds_dict["RDSInstance"]["Properties"],
                         "test_rds: template does not contain DBInstanceIdentifier")
         identifier = rds_dict["RDSInstance"]["Properties"]["DBInstanceIdentifier"]
-        # identifier starts RDS and contains an 8 char uuid plus stack name
-        # so this should always be true
-        self.assertTrue(len(identifier) >= 12)
+        # Identifier can be optionally be defined in the yaml template for compatibility.
+        # We're only testing the case where it's defined. If left undefined AWS will
+        # generate a random one.
+        self.assertEquals(identifier, 'test-dev')
         rds_dict["RDSInstance"]["Properties"].pop("DBInstanceIdentifier")
         known = self._resources_to_dict(known)
         compare(known, rds_dict)


### PR DESCRIPTION
This removes the use of the RDS identifier setting.
- Pass template to config:rds method
- Randomise a DBInstanceIdentifierName
- Update tests to use template passed to rds()
- Changed 2 test comparisons to standard expected_data, actual_data order
- Drop mention of identifier from sample project

(Closes ministryofjustice/bootstrap-cfn#137)
