### PR TITLE
ELB Automatic resource naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
   This is used by bootstrap-salt to remove a file that it places and manages
   in an S3 bucket so that the stack can be cleanly deleted.
 
+* Let Cloudformation name the ELBs automatically to make creating multiple
+  stacks easier.
+
+  The 'name' parameter in each load balancer config is now only used to
+  generate the DNS entries.
+
 ## Version 0.5.6
 * Automaticly generate the RDS identifier
 


### PR DESCRIPTION
This change removes settings LoadBalancerName manually and
uses the AWS auto naming instead.
- Do not set LoadBalancerName manually, use AWS auto naming
- Add elb dns names as outputs
- Pass troposphere template to elb function so that resources
  and outputs can be set up internal to the function
- Update tests for elb method requiring template and resultant
  need to seperate out resource componenents for comparison
- PEP8 fixes for test.py and test_iam.py

(Closes ministryofjustice/bootstrap-cfn#136)
