### PR TITLE
Provide hook point in cfn_delete after confirm but before DeleteStack call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Version 0.5.x
+
+* Provide hook point in cfn_delete fab task after confirm but before
+  DeleteStack call.
+
+  This is used by bootstrap-salt to remove a file that it places and manages
+  in an S3 bucket so that the stack can be cleanly deleted.
+
 ## Version 0.5.6
 * Automaticly generate the RDS identifier
 


### PR DESCRIPTION
This is used by bootstrap-salt to delete a file that it manages in an s3
bucket that would otherwise stop the stack from deleting.
