### PR TITLE
If no cloud_config is provided but we are setting the hostname, set manage_etc_hosts to True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,17 @@
   generate the DNS entries.
 
 ## Version 0.5.6
+
 * Automaticly generate the RDS identifier
 
 ## Version 0.5.5
-* Make it possible to override the ConfigParser so that sub-modules can update the CloudFormation config.
-* Use a automatic resource naming to allow S3 bucket names to be auto named by AWS
-* Added a new task `display_elb_dns_entries` to show the DNS name of each ELB in a stack
+
+* Make it possible to override the ConfigParser so that sub-modules can update
+  the CloudFormation config.
+* Use a automatic resource naming to allow S3 bucket names to be auto named by
+  AWS
+* Added a new task `display_elb_dns_entries` to show the DNS name of each ELB
+  in a stack
 
 ## Version 0.5.4
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1294,9 +1294,26 @@ class TestConfigParser(unittest.TestCase):
         }
         config = ConfigParser(data, environment="env", application="test", stack_name="my-stack")
         with patch.object(config, 'get_hostname_boothook', return_value={"content": "sentinel"}) as mock_boothook:
-            compare(yaml.load(config.get_ec2_userdata()[1]['content']), data['ec2']['cloud_config'])
+            user_data_parts = config.get_ec2_userdata()
             mock_boothook.assert_called_once_with(data['ec2'])
-            compare(config.get_ec2_userdata()[0]['content'], 'sentinel')
+
+            compare(yaml.load(user_data_parts[1]['content']), data['ec2']['cloud_config'])
+            compare(user_data_parts[0]['content'], 'sentinel')
+
+    def test_get_ec2_userdata_no_cloud_config(self):
+        # If there is no cloud config we should get a default
+        # 'manage_etc_hosts' because of the default hostname pattern
+        data = {
+            'ec2': {
+            }
+        }
+        config = ConfigParser(data, environment="env", application="test", stack_name="my-stack")
+        with patch.object(config, 'get_hostname_boothook', return_value={"content": "sentinel"}) as mock_boothook:
+            user_data_parts = config.get_ec2_userdata()
+            mock_boothook.assert_called_once_with(data['ec2'])
+
+            compare(yaml.load(user_data_parts[1]['content']), {'manage_etc_hosts': True})
+            compare(user_data_parts[0]['content'], 'sentinel')
 
     def test_get_hostname_boothook(self):
         config = ConfigParser({}, environment="env", application="test", stack_name="my-stack")


### PR DESCRIPTION
This behaviour can be overridden but means we don't end up with 'sudo:
cannot resolve hostname' errors on initial boot.
