### PR TITLE
Make db-name field optional for sqlserver based RDS instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Version UNRELEASED
 
 * Update the AWS AMI to the latest ubuntu, which includes the new kernel.
+* Partially support sqlserver based RDS instances - which *cannot* have a
+  DBName specified, so make that field not required for sqlserver backed
+  instances.
 
 ## Version 0.5.7
 

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -372,6 +372,10 @@ class ConfigParser(object):
         )
         resources.append(rds_instance)
 
+        # We *cant* specify db-name for SQL Server based RDS instances. :(
+        if 'db-engine' in self.data['rds'] and self.data['rds']['db-engine'].startswith("sqlserver"):
+            required_fields.pop('db-name')
+
         # TEST FOR REQUIRED FIELDS AND EXIT IF MISSING ANY
         for yaml_key, rds_prop in required_fields.iteritems():
             if yaml_key not in self.data['rds']:


### PR DESCRIPTION
Ideally we'd actually make the field required to be not set for these
types of DB servers but that is more work and this gives us minial support
