### PR TITLE
Check for AWS_ROLE_ARN_ID in utils:connect_to_aws before assuming role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## UNRELEASED
+
+* Change AWS connection to use STS AssumeRole when AWS_ROLE_ARN_ID
+environment variable is specified in addition to just the profile being
+called "cross-account".
+
 ## Version 0.5.9
 
 * Bump version

--- a/bootstrap_cfn/utils.py
+++ b/bootstrap_cfn/utils.py
@@ -28,7 +28,11 @@ def timeout(timeout, interval):
 
 def connect_to_aws(module, instance):
     try:
-        if instance.aws_profile_name == 'cross-account':
+        # Check if we have a AWS_ROLE_ARN_ID set, if so we will attempt
+        # to assume a role and connect no matter whether we're on the
+        # cross-account profile or not.
+        if (instance.aws_profile_name == 'cross-account' or
+                os.environ.get('AWS_ROLE_ARN_ID', False)):
             sts = boto.sts.connect_to_region(
                 region_name=instance.aws_region_name,
                 profile_name=instance.aws_profile_name


### PR DESCRIPTION
connect_to_aws checks for the cross-account profile and then tries to
assume a role based on that. This means that if are not using the
cross-account as a profile name we will skip assuming roles. This change
will also attempt to assume a role if we have a AWS_ROLE_ARN_ID variable
set.
