### PR TITLE
Added elasticache with engine redis

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ If your ``$CWD`` is anywhere else, you need to pass in a path to particular fabr
 - **config:/path/to/file.yaml** - The location to the project YAML file
 
 Multiple Stacks
-=================
+===============
 
 If you want to run multiple stacks with the same name and environment place the following in the yaml configuration::
 
@@ -285,6 +285,22 @@ It is possilbe to define a custom health check for an ELB like follows::
       Timeout: 5
       UnhealthyThreshold: 2
 
+Elasticache
++++++++++++
+
+By specifying an elasticache section, a redis-backed elasticache replication group will be created. The group name will be available as an output.
+
+::
+
+   elasticache:                     # (REQUIRED) Main elasticache key, use {} for all default settings. Defaults are shown
+      clusters: 3                   # (OPTIONAL) Number of one-node clusters to create
+      node_type: cache.m1.small     # (OPTIONAL) The node type of the clusters nodes
+      port: 6379                    # (OPTIONAL) Port number 
+      seeds:                        # (OPTIONAL) List of arns to seed the database with
+         s3:                        # (OPTIONAL) List of S3 bucket seeds in <bucket>/<filepath> format
+            - "test-bucket-947923urhiuy8923d/redis.rdb"
+
+
 Applying a custom s3 policy
 +++++++++++++++++++++++++++
 You can add a custom s3 policy to override bootstrap-cfn's default settings. For example, the sample custom policy defined in this `json file <https://github.com/ministryofjustice/bootstrap-cfn/blob/master/tests/sample-custom-s3-policy.json>`_ can be configured as follows:
@@ -305,7 +321,7 @@ If you wish to include some static cloudformation json and have it merged with t
 The tool will then perform a deep merge of the includes with the generated template dictionary. Any keys or subkeys in the template dictionary that clash will have their values **overwritten** by the included dictionary or recursively merged if the value is itself a dictionary.
 
 ConfigParser
-++++++++++++++
+++++++++++++
 If you want to include or modify cloudformation resources but need to include some logic and not a static include. You can subclass the ConfigParser and set the new class as `env.cloudformation_parser` in your fabfile.
 
 

--- a/tests/sample-project.yaml
+++ b/tests/sample-project.yaml
@@ -63,6 +63,13 @@ dev:
     multi-az: false
     db-engine: postgres
     db-engine-version: 9.3.5
+  elasticache:
+    clusters: 3
+    node_type: cache.m1.small
+    port: 10024
+    seeds:
+      s3:
+      - somebucket/redis.rdb
   ssl:
     my-cert:
       cert: |

--- a/tests/test.py
+++ b/tests/test.py
@@ -176,7 +176,7 @@ class CfnTestCase(unittest.TestCase):
         with self.assertRaises(errors.CfnTimeoutError):
             print cloudformation.Cloudformation(
                 self.env.aws_profile).wait_for_stack_done(self.stack_name, 1, 1)
-        
+
     def test_wait_for_stack_done(self):
         stack_evt_mock = mock.Mock()
         rt = mock.PropertyMock(return_value='AWS::CloudFormation::Stack')

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -10,6 +10,7 @@ from testfixtures import compare
 from troposphere import Base64, FindInMap, GetAZs, GetAtt, Join, Ref, Template, awsencode, ec2, iam, rds, s3
 from troposphere.autoscaling import AutoScalingGroup, LaunchConfiguration, Tag
 from troposphere.ec2 import SecurityGroup, SecurityGroupIngress
+from troposphere.elasticache import ReplicationGroup, SubnetGroup
 from troposphere.elasticloadbalancing import ConnectionDrainingPolicy, HealthCheck, LoadBalancer, Policy
 from troposphere.iam import PolicyType
 from troposphere.route53 import RecordSetGroup
@@ -34,7 +35,7 @@ class TestConfig(unittest.TestCase):
         self.assertEquals(
             sorted(
                 config.config.keys()), [
-                'ec2', 'elb', 'rds', 's3', 'ssl'])
+                'ec2', 'elasticache', 'elb', 'rds', 's3', 'ssl'])
 
     def test_project_config_merge_password(self):
         '''
@@ -326,8 +327,70 @@ class TestConfigParser(unittest.TestCase):
         actual_outputs = self._resources_to_dict(template.outputs.values())
         compare(expected_outputs, actual_outputs)
 
+    def test_elasticache(self):
+        es_sg = SecurityGroup(
+            "ElasticacheSG",
+            SecurityGroupIngress=[
+                {"ToPort": 10024,
+                 "FromPort": 10024,
+                 "IpProtocol": "tcp",
+                 "CidrIp": FindInMap("SubnetConfig", "VPC", "CIDR")}
+            ],
+            VpcId=Ref("VPC"),
+            GroupDescription="SG for EC2 Access to Elasticache",
+        )
+
+        es_subnet_group = SubnetGroup(
+            'ElasticacheSubnetGroup',
+            Description="Elasticache Subnet Group",
+            SubnetIds=[Ref("SubnetA"), Ref("SubnetB"), Ref("SubnetC")]
+            )
+
+        elasticache_replication_group = ReplicationGroup(
+            "ElasticacheReplicationGroup",
+            ReplicationGroupDescription='Elasticache Replication Group',
+            Engine='redis',
+            NumCacheClusters=3,
+            CacheNodeType='cache.m1.small',
+            SecurityGroupIds=[GetAtt(es_sg, "GroupId")],
+            CacheSubnetGroupName=Ref(es_subnet_group),
+            SnapshotArns=["arn:aws:s3:::somebucket/redis.rdb"],
+            Port=10024
+        )
+
+        known = [elasticache_replication_group,
+                 es_subnet_group,
+                 es_sg]
+
+        config = ConfigParser(
+            ProjectConfig(
+                'tests/sample-project.yaml',
+                'dev',
+                'tests/sample-project-passwords.yaml').config, 'my-stack-name')
+
+        template = Template()
+        config.elasticache(template)
+        resources = template.resources.values()
+        es_dict = self._resources_to_dict(resources)
+
+        known = self._resources_to_dict(known)
+        compare(known, es_dict)
+
+        # Test for outputs
+        expected_outputs = {
+            "ElasticacheReplicationGroupName": {
+                "Description": "Elasticache Replication Group Name",
+                "Value": {"Ref": "ElasticacheReplicationGroup"}
+            },
+            "ElasticacheEngine": {
+                "Description": "Elasticache Engine",
+                "Value": "redis"
+            }
+        }
+        actual_outputs = self._resources_to_dict(template.outputs.values())
+        compare(expected_outputs, actual_outputs)
+
     def test_elb(self):
-        known = []
         lb = LoadBalancer(
             "ELBtestdevinternal",
             ConnectionDrainingPolicy=ConnectionDrainingPolicy(
@@ -631,6 +694,14 @@ class TestConfigParser(unittest.TestCase):
             "ELBtestdevinternal": {
                 "Description": "ELB DNSName",
                 "Value": {"Fn::GetAtt": ["ELBtestdevinternal", "DNSName"]}
+            },
+            "ElasticacheEngine": {
+                "Description": "Elasticache Engine",
+                "Value": "redis"
+            },
+            "ElasticacheReplicationGroupName": {
+                "Description": "Elasticache Replication Group Name",
+                "Value": {"Ref": "ElasticacheReplicationGroup"}
             }
         }
         config = ConfigParser(project_config.config, 'my-stack-name')
@@ -656,7 +727,8 @@ class TestConfigParser(unittest.TestCase):
             "BaseHostRole", "BaseHostSG", "BaseHostSGRule0", "BaseHostSGRule1", "DNStestdevexternal",
             "DNStestdevinternal", "DatabaseSG", "DefaultSGtestdevexternal",
             "DefaultSGtestdevinternal", "ELBtestdevexternal",
-            "ELBtestdevinternal", "InstanceProfile", "InternetGateway",
+            "ELBtestdevinternal", "ElasticacheReplicationGroup",
+            "ElasticacheSG", "ElasticacheSubnetGroup", "InstanceProfile", "InternetGateway",
             "Policytestdevexternal", "Policytestdevinternal", "PublicRoute",
             "PublicRouteTable", "RDSInstance", "RDSSubnetGroup",
             "RolePolicies", "ScalingGroup", "StaticBucket",
@@ -671,6 +743,8 @@ class TestConfigParser(unittest.TestCase):
 
         wanted = ["ELBtestdevexternal",
                   "ELBtestdevinternal",
+                  "ElasticacheEngine",
+                  "ElasticacheReplicationGroupName",
                   "StaticBucketName",
                   "dbhost",
                   "dbport"]
@@ -716,7 +790,8 @@ class TestConfigParser(unittest.TestCase):
             "BaseHostRole", "BaseHostSG", "BaseHostSGRule0", "BaseHostSGRule1", "DNStestdevexternal",
             "DNStestdevinternal", "DatabaseSG", "DefaultSGtestdevexternal",
             "DefaultSGtestdevinternal", "ELBtestdevexternal",
-            "ELBtestdevinternal", "InstanceProfile", "InternetGateway",
+            "ELBtestdevinternal", "ElasticacheReplicationGroup",
+            "ElasticacheSG", "ElasticacheSubnetGroup", "InstanceProfile", "InternetGateway",
             "Policytestdevexternal", "Policytestdevinternal", "PublicRoute",
             "PublicRouteTable", "RDSInstance", "RDSSubnetGroup",
             "RolePolicies", "ScalingGroup", "StaticBucket",
@@ -731,6 +806,8 @@ class TestConfigParser(unittest.TestCase):
 
         wanted = ["ELBtestdevexternal",
                   "ELBtestdevinternal",
+                  "ElasticacheEngine",
+                  "ElasticacheReplicationGroupName",
                   "StaticBucketName",
                   "dbhost",
                   "dbport"]


### PR DESCRIPTION
Can now add an elasticache section to the template to get a redis
based elasticache. The number of clusters in the replication group,
node_type and port can be specified. A list of redis backup files
can be provided also, to seed the new elasticache resource.
The replication groups name and engine is provided as an output.

``` yaml
elasticache:
  clusters: 3
  node_type: cache.m1.small
  port: 10024
  seeds:
    s3:
    - test-redis-bucket-947923urhiuy8923d/redis.rdb
```
