### PR TITLE
Add dynamic VPC address block subnetting

### DIFF
--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -21,7 +21,7 @@ from troposphere.s3 import Bucket, BucketPolicy
 
 import yaml
 
-from bootstrap_cfn import errors, mime_packer, utils, vpc
+from bootstrap_cfn import errors, mime_packer, utils
 
 
 class ProjectConfig:
@@ -89,7 +89,7 @@ class ConfigParser(object):
             template, sort_keys=True, indent=4, separators=(',', ': '))
 
     def base_template(self):
-
+        from bootstrap_cfn import vpc
         t = Template()
 
         t.add_mapping("AWSRegion2AMI", {

--- a/bootstrap_cfn/vpc.py
+++ b/bootstrap_cfn/vpc.py
@@ -1,0 +1,65 @@
+import logging
+
+import boto3
+
+import netaddr
+
+# Setup the logging
+logger = logging.getLogger('vpc_available_addresses')
+logger.setLevel(logging.INFO)
+loghandler = logging.StreamHandler()
+logger.addHandler(loghandler)
+
+
+def get_available_addresses():
+    """
+    Get the unused networks CIDR for all vpcs in this account
+
+    Returns:
+        (list): List of available IPNetworks in CIDR notation
+    """
+    ec2_client = boto3.client('ec2')
+    vpcs = ec2_client.describe_vpcs().get('Vpcs', [])
+    vpc_cidr_mappings = {}
+    for vpc in vpcs:
+        vpc_cidr_mappings[vpc['VpcId']] = vpc['CidrBlock']
+
+    private_ipv4_address_space = netaddr.IPSet(['10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16'])
+    used_ipv4_address_space = netaddr.IPSet(vpc_cidr_mappings.values())
+    available_ipv4_address_space = private_ipv4_address_space ^ used_ipv4_address_space
+    return available_ipv4_address_space
+
+
+def get_available_cidr_block(cidr_prefix, subnet_prefix=28):
+    """
+    Get the first unused available VPC CIDR block plus the
+    available subnets
+
+    Args:
+        cidr_prefix(int): The cidr prefix to the main vpc address block
+        subnet_prefix(int): The cidr prefix to the main vpc address subnet blocks
+
+    Returns:
+        (string): The main vpc address block, None if not found
+        (list): The main vpc address block subnets, None if not found
+    """
+    available_addresses = get_available_addresses()
+    if len(available_addresses) > 0:
+        # Find the first group that we can subnet succesfully
+        for available_address_cidr in available_addresses.iter_cidrs():
+            free_cidr_blocks = list(available_address_cidr.subnet(cidr_prefix))
+            if len(free_cidr_blocks) > 0:
+
+                free_cidr_block = free_cidr_blocks[0]
+                subnet_cidr_blocks = list(free_cidr_block.subnet(subnet_prefix))
+
+                free_cidr_blockstr = str(free_cidr_block)
+                subnet_cidr_blocksstr = [str(cidr) for cidr in subnet_cidr_blocks]
+                logger.info("get_available_cidr_blocks: Found free cidr block, '%s'"
+                            " with subnets '%s'"
+                            % (free_cidr_blockstr, subnet_cidr_blocksstr))
+                return free_cidr_blockstr, subnet_cidr_blocksstr
+            else:
+                logger.info("get_available_cidr_blocks: Could not subnet CIDR '%s'"
+                            % (available_address_cidr))
+    return None, None

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Fabric==1.10.1
 PyYAML==3.11
 boto==2.36.0
 mock==1.0.1
+netaddr==0.7.18
 testfixtures==4.1.2
 paramiko
 troposphere>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Fabric==1.10.1
 PyYAML==3.11
 boto==2.36.0
+boto3==1.2.2
 mock==1.0.1
 netaddr==0.7.18
 testfixtures==4.1.2

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         'Fabric>=1.10.1',
         'PyYAML>=3.11',
         'boto>=2.36.0',
+        'netaddr>=0.7.18',
         'troposphere>=1.0.0',
     ],
     setup_requires=[

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         'Fabric>=1.10.1',
         'PyYAML>=3.11',
         'boto>=2.36.0',
+        'boto3>=1.2.2',
         'netaddr>=0.7.18',
         'troposphere>=1.0.0',
     ],

--- a/tests/sample-project.yaml
+++ b/tests/sample-project.yaml
@@ -1,4 +1,9 @@
 dev:
+  vpc:
+    CIDR: 10.0.0.0/16
+    SubnetA: 10.0.0.0/20
+    SubnetB: 10.0.16.0/20
+    SubnetC: 10.0.32.0/20
   ec2:
     auto_scaling:
       desired: 1

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -35,7 +35,7 @@ class TestConfig(unittest.TestCase):
         self.assertEquals(
             sorted(
                 config.config.keys()), [
-                'ec2', 'elasticache', 'elb', 'rds', 's3', 'ssl'])
+                'ec2', 'elasticache', 'elb', 'rds', 's3', 'ssl', 'vpc'])
 
     def test_project_config_merge_password(self):
         '''


### PR DESCRIPTION
This change will mean that there will be an attempt made to
dynamically get unassigned address ranges from within the VPC that
the new VPC will use. The progression is,
- Use VPC subnets from config file if they exist
- If not, try to get an unused address range in the VPC
- If all of the above fail, use the default hardcoded VPC addresses
