### PR TITLE
Add vpc peering advanced

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,7 @@ The objective of this repo is to enable MoJ teams to create project infrastructu
 - Elastic Load Balancers (ELB)
 - Relational Database Service (RDS)
 - S3 Storage for web static content
+- `VPC Configuration <docs/vpc-configuration.md>`_
 
 Installation
 ============

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -98,10 +98,11 @@ class ConfigParser(object):
 
         if 'vpc' in self.data:
             logging.info('bootstrap-cfn::base_template: Using configuration VPC address settings')
-            vpc_cidr = self.data.get('vpc', {}).get('CIDR', '10.0.0.0/16')
-            subneta_cidr = self.data.get('SubnetA', {}).get('CIDR', '10.0.0.0/20')
-            subnetb_cidr = self.data.get('SubnetB', {}).get('CIDR', '10.0.16.0/20')
-            subnetc_cidr = self.data.get('SubnetC', {}).get('CIDR', '10.0.32.0/20')
+            vpc_data = self.data.get('vpc', {})
+            vpc_cidr = vpc_data.get('CIDR', '10.0.0.0/16')
+            subneta_cidr = vpc_data.get('SubnetA', '10.0.0.0/20')
+            subnetb_cidr = vpc_data.get('SubnetB', '10.0.16.0/20')
+            subnetc_cidr = vpc_data.get('SubnetC', '10.0.32.0/20')
             t.add_mapping("SubnetConfig", {
                 "VPC": {
                     "CIDR": vpc_cidr,
@@ -143,9 +144,7 @@ class ConfigParser(object):
                     "SubnetC": subnetc_cidr
                 }
             })
-=======
 
->>>>>>> 234e59f... Add advanced settings and wildcards for peering vpcs
         return t
 
     def vpc(self):

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -98,17 +98,16 @@ class ConfigParser(object):
 
         if 'vpc' in self.data:
             logging.info('bootstrap-cfn::base_template: Using configuration VPC address settings')
-            cidr = self.data.get('vpc', {}).get('CIDR', '10.0.0.0/16')
-            subneta = self.data.get('SubnetA', {}).get('CIDR', '10.0.0.0/20')
-            subnetb = self.data.get('SubnetB', {}).get('CIDR', '10.0.16.0/20')
-            subnetc = self.data.get('SubnetC', {}).get('CIDR', '10.0.32.0/20')
-    
+            vpc_cidr = self.data.get('vpc', {}).get('CIDR', '10.0.0.0/16')
+            subneta_cidr = self.data.get('SubnetA', {}).get('CIDR', '10.0.0.0/20')
+            subnetb_cidr = self.data.get('SubnetB', {}).get('CIDR', '10.0.16.0/20')
+            subnetc_cidr = self.data.get('SubnetC', {}).get('CIDR', '10.0.32.0/20')
             t.add_mapping("SubnetConfig", {
                 "VPC": {
-                    "CIDR": "10.0.0.0/16",
-                    "SubnetA": "10.0.0.0/20",
-                    "SubnetB": "10.0.16.0/20",
-                    "SubnetC": "10.0.32.0/20"
+                    "CIDR": vpc_cidr,
+                    "SubnetA": subneta_cidr,
+                    "SubnetB": subnetb_cidr,
+                    "SubnetC": subnetc_cidr
                 }
             })
         else:
@@ -144,6 +143,9 @@ class ConfigParser(object):
                     "SubnetC": subnetc_cidr
                 }
             })
+=======
+
+>>>>>>> 234e59f... Add advanced settings and wildcards for peering vpcs
         return t
 
     def vpc(self):

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -98,8 +98,18 @@ class ConfigParser(object):
 
         if 'vpc' in self.data:
             logging.info('bootstrap-cfn::base_template: Using configuration VPC address settings')
+            cidr = self.data.get('vpc', {}).get('CIDR', '10.0.0.0/16')
+            subneta = self.data.get('SubnetA', {}).get('CIDR', '10.0.0.0/20')
+            subnetb = self.data.get('SubnetB', {}).get('CIDR', '10.0.16.0/20')
+            subnetc = self.data.get('SubnetC', {}).get('CIDR', '10.0.32.0/20')
+    
             t.add_mapping("SubnetConfig", {
-                "VPC": self.data['vpc']
+                "VPC": {
+                    "CIDR": "10.0.0.0/16",
+                    "SubnetA": "10.0.0.0/20",
+                    "SubnetB": "10.0.16.0/20",
+                    "SubnetC": "10.0.32.0/20"
+                }
             })
         else:
             default_vpc_cidr_prefix = 24

--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -20,6 +20,7 @@ from bootstrap_cfn.errors import CloudResourceNotFoundError
 from bootstrap_cfn.iam import IAM
 from bootstrap_cfn.r53 import R53
 from bootstrap_cfn.utils import tail
+from bootstrap_cfn.vpc import VPC
 
 
 # Default fab config. Set via the tasks below or --set
@@ -563,3 +564,29 @@ def display_elb_dns_entries():
     elb_dns_list = elb.list_domain_names(stack_name)
     for elb_dns in elb_dns_list:
         print "\n\nELB name: {0}        DNS: {1}".format(elb_dns['elb_name'], elb_dns['dns_name'])
+
+
+@task
+def enable_vpc_peering():
+    """
+    Enables vpc peering to stacks named in the cloudformation config.
+    """
+    # peer vpc
+    cfg = get_config()
+    vpc_cfg = cfg.data.get('vpc', False)
+    if vpc_cfg:
+        vpc_obj = VPC(cfg, get_stack_name())
+        vpc_obj.enable_peering()
+
+
+@task
+def disable_vpc_peering():
+    """
+    Disables vpc peering to stacks named in the cloudformation config.
+    """
+    # peer vpc
+    cfg = get_config()
+    vpc_cfg = cfg.data.get('vpc', False)
+    if vpc_cfg:
+        vpc_obj = VPC(cfg, get_stack_name())
+        vpc_obj.disable_peering()

--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -575,7 +575,7 @@ def enable_vpc_peering():
     cfg = get_config()
     vpc_cfg = cfg.data.get('vpc', False)
     if vpc_cfg:
-        vpc_obj = VPC(cfg, get_stack_name())
+        vpc_obj = VPC(cfg.data, get_stack_name())
         vpc_obj.enable_peering()
 
 
@@ -588,5 +588,5 @@ def disable_vpc_peering():
     cfg = get_config()
     vpc_cfg = cfg.data.get('vpc', False)
     if vpc_cfg:
-        vpc_obj = VPC(cfg, get_stack_name())
+        vpc_obj = VPC(cfg.data, get_stack_name())
         vpc_obj.disable_peering()

--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -427,6 +427,10 @@ def cfn_delete(force=False, pre_delete_callbacks=None):
         for callback in pre_delete_callbacks:
             callback(stack_name=stack_name, config=cfn_config)
 
+    # Disable all vpc peering before deletion
+    print green("\nSTACK {0}: Disabling VPC peering before deletion...\n").format(stack_name)
+    disable_vpc_peering()
+
     print green("\nSTACK {0} DELETING...\n").format(stack_name)
 
     cfn.delete(stack_name)

--- a/bootstrap_cfn/vpc.py
+++ b/bootstrap_cfn/vpc.py
@@ -1,8 +1,468 @@
 import logging
 
+import time
+
 import boto3
 
+from botocore.exceptions import ClientError
+
+from bootstrap_cfn import cloudformation
+
 import netaddr
+
+
+class VPC:
+    """
+    Class used to work with stack VPC's. It allows the peering of
+    VPC's through the use of configuration data on target stacks
+    """
+    # Configuration data
+    config = None
+    vpc_config = {}
+    peering_config = {}
+
+    # Stacks vpc id
+    vpc_id = None
+
+    logger = None
+
+    def __init__(self, config, stack_name):
+        """
+        Default initialiser
+
+        Args:
+            cfg(dict): The cloudformation configuration data
+            stack_name(string): The name of the current stack
+        """
+        # Setup logging
+        logging.getLogger('boto3').setLevel(logging.CRITICAL)
+        logging.getLogger('botocore').setLevel(logging.CRITICAL)
+        self.logger = logging.getLogger('bootstrap_cfn')
+        self.logger.setLevel(logging.INFO)
+        self.config = config
+        self.vpc_config = self.config.data.get('vpc', {})
+        self.peering_config = self.vpc_config.get('peering', {})
+        self.vpc_id = self.get_stack_vpc_id(stack_name)
+
+    def disable_peering(self,
+                        stack_name=None,
+                        target_limit=1):
+        """
+        Disable VPC peering to stacks
+
+        Args:
+            stack_name(string): The search stack name for the peering stack. Since
+                stack names have a randomised element this allows us to adapt and
+                target the same stack even when its recreated.
+            target_limit(int): Set the number of peering target stacks we should limit
+                our matches to.
+        """
+        if not stack_name:
+            for peer_stack in self.peering_config.keys():
+                found_stacks = self.get_stack_name_by_match(peer_stack, min_results=1, max_results=target_limit)
+                if found_stacks:
+                    for found_stack in found_stacks:
+                        stack_name = found_stack.get('StackName')
+                        self.delete_peering_routes(stack_name)
+                        self.delete_peering_connections(stack_name, target_limit=1)
+        else:
+            self.delete_peering_connections(stack_name)
+
+    def enable_peering(self,
+                       stack_name=None,
+                       target_limit=1):
+        """
+        Peer stacks with this one
+
+        Args:
+            stack_name(string): The search stack name for the peering stack. Since
+                stack names have a randomised element this allows us to adapt and
+                target the same stack even when its recreated.
+            target_limit(int): Set the number of peering target stacks we should limit
+                our matches to.
+        """
+        if not stack_name:
+            for peer_stack in self.peering_config.keys():
+                found_stacks = self.get_stack_name_by_match(peer_stack, min_results=1, max_results=target_limit)
+                if found_stacks:
+                    for found_stack in found_stacks:
+                        stack_name = found_stack.get('StackName')
+                        self.peer_to_stack(stack_name)
+        else:
+            self.peer_to_stack(stack_name)
+
+    def peer_to_stack(self,
+                      peer_stack_name):
+        """
+        Create a peering connection to the names stack and create routes between
+        peered vpcs in their respective default route tables
+
+        Args:
+            peer_stack_name(string): The name of the stack to peer this one to
+        """
+
+        peer_vpc_id = self.get_stack_vpc_id(peer_stack_name)
+        if not peer_vpc_id:
+            self.logger.error("VPC::peer_to_stack: Unique vpc not found for stack '%s'"
+                              % (peer_stack_name))
+            return False
+
+        ec2_resource = boto3.resource('ec2')
+        #  PeerOwnerId='string' can be set for peering different accoutns
+        vpc_peering_connection = ec2_resource.create_vpc_peering_connection(
+            VpcId=self.vpc_id,
+            PeerVpcId=peer_vpc_id,
+        )
+        self.logger.info("VPC::peer_to_stack: Creating peering connection '%s'"
+                         % (vpc_peering_connection.id))
+
+        # Have the peer target stack accept the peering
+        ec2_client = boto3.client('ec2')
+        ec2_client.accept_vpc_peering_connection(
+            VpcPeeringConnectionId=vpc_peering_connection.id
+        )
+        self.logger.info("VPC::peer_to_stack: Accepting peering connection '%s'"
+                         % (vpc_peering_connection.id))
+        # wait for required state
+        self.wait_for_connection_states(
+            vpc_peering_connection,
+            status_codes=['pending-acceptance', 'provisioning', 'active'])
+        # setup routes
+        self.logger.info("VPC::peer_to_stack: Creating peering routes...")
+        self.create_peering_routes(vpc_peering_connection)
+        # setup ACL
+        # TODO
+
+    def wait_for_connection_states(self,
+                                   peering_conn,
+                                   status_codes=['active'],
+                                   timeout=15):
+        """
+        Wait for a peering connection to enter a specified state within
+        a timeout period
+
+        Args:
+            peering_conn(VPCPeeringConnection): The peering connection to monitor
+            status_codes(list): List of status codes to wait on
+            timeout(int): The timeout period in seconds to wait before giving up
+        """
+        wait_end = time.time() + timeout
+        while wait_end > time.time():
+            peering_conn.reload()
+            if peering_conn.status['Code'] in status_codes:
+                return True
+
+            time.sleep(1)
+        return False
+
+    def create_peering_routes(self,
+                              peering_conn):
+        """
+        Create the routes from this stack to the peering stack and
+        vice versa. By default we will route all CIDR in each peered
+        VPC
+
+        Args:
+            peering_conn(VPCPeeringConnection): The peering connection to route
+                to route to and from
+        """
+        self.create_route_vpc_to_vpc_peer(
+            vpc_id=peering_conn.requester_vpc_info['VpcId'],
+            target_vpc_cidr=peering_conn.accepter_vpc_info['CidrBlock'],
+            peering_conn_id=peering_conn.id
+        )
+        self.create_route_vpc_to_vpc_peer(
+            vpc_id=peering_conn.accepter_vpc_info['VpcId'],
+            target_vpc_cidr=peering_conn.requester_vpc_info['CidrBlock'],
+            peering_conn_id=peering_conn.id
+        )
+
+    def delete_peering_routes(self, stack_search_name, target_limit=1):
+        """
+        Deletes the VPC peering routes from source and target vpcs. This
+        will match anything in stack_search_name up to the target limit
+
+        Args:
+            stack_search_name(string): The search name of the peered stacks
+            target_limit(int): The limit on the number of stack search results
+        """
+        peering_conns = self.get_stack_peering_connections(stack_search_name)
+
+        if not peering_conns:
+            self.logger.error("vpc::delete_peering_routes: "
+                              "Peering_connections for stack id '%s' not found"
+                              % stack_search_name)
+            return False
+
+        if len(peering_conns) > target_limit:
+            self.logger.error("vpc::delete_peering_routes: "
+                              "Too many peering connection matches for stack name '%s'"
+                              % stack_search_name)
+            return False
+
+        for peering_conn in peering_conns:
+            self.delete_route_vpc_to_vpc_peer(
+                vpc_id=peering_conn.requester_vpc_info['VpcId'],
+                target_vpc_cidr=peering_conn.accepter_vpc_info['CidrBlock']
+            )
+            self.delete_route_vpc_to_vpc_peer(
+                vpc_id=peering_conn.accepter_vpc_info['VpcId'],
+                target_vpc_cidr=peering_conn.requester_vpc_info['CidrBlock']
+            )
+
+    def delete_peering_connections(
+        self,
+        stack_search_name,
+        target_limit=1
+    ):
+        """
+        Deletes a VPC peering connection
+
+        Args:
+            stack_search_name(string): The search name of the peered stacks
+            target_limit(int): The limit on the number of stack search results
+        """
+        peering_conns = self.get_stack_peering_connections(stack_search_name)
+
+        if not peering_conns:
+            self.logger.error("vpc::delete_peering_connections: "
+                              "Peering_connections for stack id '%s' not found"
+                              % stack_search_name)
+            return False
+
+        if len(peering_conns) > target_limit:
+            self.logger.error("vpc::delete_peering_connections: "
+                              "Too many peering connections matches for stack name '%s'"
+                              % stack_search_name)
+            return False
+
+        for peering_conn in peering_conns:
+            if not peering_conn.delete():
+                self.logger.error("vpc::delete_peering_connections: "
+                                  "Error deleting peering connection to stack '%s'"
+                                  % stack_search_name)
+
+        return True
+
+    def get_stack_peering_connections(self, stack_name, status_codes=['active']):
+        """
+        Get all of the peering connections withing a stack that have the specified status
+
+        Args:
+            stack_name(string): The name of the stack
+            status_codes(list): The list of status codes to filter the peering connection on.
+                Possible values are pending-acceptance, failed, expired, provisioning, active, deleted, rejected
+
+        Returns:
+            (list): The VPCPeeringConnections belonging to the specified stack
+        """
+        ec2_client = boto3.client('ec2')
+        ec2_resource = boto3.resource('ec2')
+        peering_connections = []
+        peering_connection_filter = [{'Name': 'requester-vpc-info.vpc-id', 'Values': [self.vpc_id]}]
+        if status_codes:
+            peering_connection_filter.append({'Name': 'status-code', 'Values': status_codes})
+        if stack_name:
+            peer_stack_vpc_id = self.get_stack_vpc_id(stack_name)
+            if peer_stack_vpc_id:
+                peering_connection_filter.append({'Name': 'accepter-vpc-info.vpc-id', 'Values': [peer_stack_vpc_id]})
+
+        # Get all peering connections
+        peering_conn_descriptions = ec2_client.describe_vpc_peering_connections(Filters=peering_connection_filter)
+
+        for peering_conn_description in peering_conn_descriptions.get('VpcPeeringConnections', []):
+            peering_conn_id = peering_conn_description['VpcPeeringConnectionId']
+            peering_connections.append(ec2_resource.VpcPeeringConnection(peering_conn_id))
+
+        return peering_connections
+
+    def get_stack_route_table_ids(
+            self,
+            stack_name):
+        """
+        Get all the route tables for the specified stack name
+
+        Args:
+            stack_name(string): The name of the stack
+
+        Returns:
+            (list): The route tables belonging to the specified stack
+        """
+        resources = cloudformation.get_resource_type(stack_name, resource_type='AWS::EC2::RouteTable')
+        if len(resources) < 1:
+            self.logger.error("VPC::get_stack_route_tables: No route tables found for stack '%s'"
+                              % (stack_name))
+            return None
+        return resources
+
+    def get_stack_vpc_id(
+            self,
+            stack_name):
+        """
+        Get the unique VPC for the specified stack name
+
+        Args:
+            stack_name(string): The name of the stack
+
+        Returns:
+            (string): The PhysicalResourceId of the vpc, None if there are multiple
+                or no vpcs found
+        """
+        vpcs = cloudformation.get_resource_type(stack_name, resource_type='AWS::EC2::VPC')
+        if len(vpcs) > 1:
+            self.logger.error("VPC::get_stack_vpc: Unique vpc not found for stack '%s'"
+                              % (stack_name))
+            return None
+        elif len(vpcs) < 1:
+            self.logger.error("VPC::get_stack_vpc: No vpc found for stack '%s'"
+                              % (stack_name))
+            return None
+        return vpcs[0]['PhysicalResourceId']
+
+    def get_stack_name_by_match(
+            self,
+            stack_search_name,
+            min_results=1,
+            max_results=1):
+        """
+        Get a set of stack names that match a search term.
+
+        Args:
+            stack_name(string): The name of the stack
+            min_results(int): The minimum number of results to expect
+            max_results(int): The maximum number of results to expect
+
+        Returns:
+            (list): The set of stack ids found
+        """
+        stack_ids = cloudformation.get_stack_ids_by_name(stack_search_name)
+
+        if len(stack_ids) > max_results:
+            self.logger.error("VPC::get_stack_name_by_match: "
+                              "Found %s results, expected maximum %s for stack '%s'"
+                              % (len(stack_ids), max_results, stack_search_name))
+            return None
+        elif len(stack_ids) < min_results:
+            self.logger.error("VPC::get_stack_name_by_match: "
+                              "Found %s results, expected minimum %s for stack '%s'"
+                              % (len(stack_ids), max_results, stack_search_name))
+            return None
+        return stack_ids
+
+    def get_vpc_route_table_ids(
+            self,
+            vpc_id,
+            logical_id_filter=None,
+            min_subnet_associations=None,
+            is_main=None):
+        """
+        Get a filtered set of route table ids for a supplied vpc
+
+        Args:
+            (string): The vpc id to get the default route
+                table for
+
+        Returns:
+            (list): The default route table id, None if
+                it wasnt found
+        """
+        route_table_ids = []
+        ec2_resource = boto3.resource('ec2')
+        vpc = ec2_resource.Vpc(vpc_id)
+
+        for route_table in list(vpc.route_tables.all()):
+            if not logical_id_filter and not min_subnet_associations and not is_main:
+                route_table_ids.append(route_table.id)
+            else:
+                if logical_id_filter:
+                    filtered_tables = [
+                        entry['Key'] for entry in route_table.tags if (
+                            entry['Key'] == 'aws:cloudformation:logical-id' and entry['Value'] == logical_id_filter)
+                    ]
+                    if len(filtered_tables) > 0:
+                        route_table_ids.append(route_table.id)
+
+                if min_subnet_associations:
+                    if (route_table.association > min_subnet_associations):
+                        route_table_ids.append(route_table.id)
+
+                if is_main:
+                    for association in list(route_table.associations.all()):
+                        if association.main is True:
+                            route_table_ids.append(route_table.id)
+        return route_table_ids
+
+    def create_route_vpc_to_vpc_peer(self,
+                                     vpc_id,
+                                     target_vpc_cidr,
+                                     peering_conn_id):
+        """
+        Create a specified cidr route from all route_tables in a VPC
+        through a peering connection.
+
+        Args:
+            vpc_id(string): The id of the vpc to remove routes from
+            target_vpc_cidr(string): The cidr of the route to remove
+            peering_connection(string): The id of the peering connection
+        """
+        ec2_client = boto3.client('ec2')
+
+        route_table_ids = self.get_vpc_route_table_ids(vpc_id, min_subnet_associations=0)
+        for route_table_id in route_table_ids:
+            try:
+                self.logger.info("VPC::create_route_vpc_to_vpc_peer: Creating route in '%s'"
+                                 " range '%s' through peering connection '%s'"
+                                 % (route_table_id, target_vpc_cidr, peering_conn_id))
+                ec2_client.create_route(
+                    RouteTableId=route_table_id,
+                    DestinationCidrBlock=target_vpc_cidr,
+                    VpcPeeringConnectionId=peering_conn_id
+                )
+            except ClientError as e:
+                if e.response['Error']['Code'] == 'RouteAlreadyExists':
+                    msg = (
+                        "vpc::route_vpc_to_vpc_peer: Adding routes to vpc, "
+                        "route '%s' already exists in table '%s',"
+                        " skipping creation"
+                        % (target_vpc_cidr, route_table_id))
+                    self.logger.warn(msg)
+                else:
+                    raise e
+
+    def delete_route_vpc_to_vpc_peer(
+            self,
+            vpc_id,
+            target_vpc_cidr):
+        """
+        Delete a specified cidr from all route_tables in a VPC
+
+        Args:
+            vpc_id(string): The id of the vpc to remove routes from
+            target_vpc_cidr(string): The cidr of the route to remove
+        """
+        ec2_client = boto3.client('ec2')
+
+        route_table_ids = self.get_vpc_route_table_ids(vpc_id, min_subnet_associations=0)
+        for route_table_id in route_table_ids:
+            try:
+                ec2_client.delete_route(
+                    RouteTableId=route_table_id,
+                    DestinationCidrBlock=target_vpc_cidr
+                )
+                self.logger.info(
+                    "vpc::delete_route_vpc_to_vpc_peer: "
+                    "Deleted cidr block '%s' from route '%s'"
+                    % (target_vpc_cidr, route_table_id)
+                )
+            except ClientError as e:
+                if e.response['Error']['Code'] == 'InvalidRoute.NotFound':
+                    msg = (
+                        "vpc::delete_route_vpc_to_vpc_peer: No route '%s' "
+                        " found in table '%s'"
+                        % (target_vpc_cidr, route_table_id))
+                    self.logger.warn(msg)
+                else:
+                    raise e
 
 # Setup the logging
 logger = logging.getLogger('vpc_available_addresses')

--- a/docs/vpc-configuration.md
+++ b/docs/vpc-configuration.md
@@ -6,17 +6,6 @@
 
 ##### [1. Basic configuration](#basic-configuration)
 
-VPC configuration is done in the under the 'vpc' key section of the cloudformation configuration file.
-
-Defaults are set so that without specifying anything, we get a VPC with CIDR `10.128.0.0/16` and 3 subnets, `10.0.0.0/20`, `10.0.16.0/20`, and `10.0.32.0/20`
-
-We can alter this by specifying the CIDR and subnets specically, for example,
-
-	vpc:
-	    CIDR: 10.128.0.0/16
-	    SubnetX: 10.128.0.0/20
-	    SubnetY: 10.128.16.0/20
-
 ##### [2. Peering](#peering)
 
 ##### [A1. Examples](#examples)
@@ -26,6 +15,17 @@ We can alter this by specifying the CIDR and subnets specically, for example,
 --------------------------------------------------------------------------
 
 ### Basic configuration 
+
+VPC configuration is done in the under the 'vpc' key section of the cloudformation configuration file.
+
+Defaults are set so that without specifying anything, we get a VPC with CIDR `10.128.0.0/16` and 3 subnets, `10.128.0.0/20`, `10.128.16.0/20`, and `10.128.32.0/20`
+
+We can alter this by specifying the CIDR and subnets specically, for example,
+
+	vpc:
+	    CIDR: 10.128.0.0/16
+	    SubnetX: 10.128.0.0/20
+	    SubnetY: 10.128.16.0/20
 
 
 ### Peering

--- a/docs/vpc-configuration.md
+++ b/docs/vpc-configuration.md
@@ -1,0 +1,159 @@
+# VPC Configuration
+
+### Contents
+
+##### [1. Basic configuration](#basic-configuration)
+
+VPC configuration is done in the under the 'vpc' key section of the cloudformation configuration file.
+
+Defaults are set so that without specifying anything, we get a VPC with CIDR `10.128.0.0/16` and 3 subnets, `10.0.0.0/20`, `10.0.16.0/20`, and `10.0.32.0/20`
+
+We can alter this by specifying the CIDR and subnets specically, for example,
+
+	vpc:
+	    CIDR: 10.128.0.0/16
+	    SubnetX: 10.128.0.0/20
+	    SubnetY: 10.128.16.0/20
+
+##### [2. Peering](#peering)
+
+##### [A1. Examples](#examples)
+
+* [Peered VPCs](#peered-vpcs)
+
+### Basic configuration 
+
+
+### Peering
+
+Using the VPC class, we can setup up peering to another VPC by calling enable_peering. This call will then
+
+* Use the cloudformation configuration file to get a list of stacks to peer to
+* Use the stack names to try and match to an existing stack, required since stack names have a random element
+* Create a peering connection between the two stacks
+* Add routes between the two stacks to each others default route table
+
+Note that if security groups are needed, these are set up separately in the security_groups section of the cloudformation configuration file.
+
+##### Setting peering stacks
+
+##### Set the security groups
+
+### Examples
+
+##### Peered VPCs
+
+	dev:
+	  vpc:
+	    CIDR: 10.128.0.0/16
+	    SubnetA: 10.128.0.0/20
+	    SubnetB: 10.128.16.0/20
+	    SubnetC: 10.128.32.0/20
+	    peering:
+	      # Peer to the stack name helloworld-dev1 with no additional configuration
+	      helloworld-dev1: {}
+	  master_zone: dsd.io
+	  ec2:
+	    auto_scaling:
+	      desired: 1
+	      max: 2
+	      min: 0
+	    tags:
+	      Role: docker
+	      Apps: helloworld
+	    parameters:
+	      KeyName: default
+	      InstanceType: t2.micro
+	    block_devices:
+	      - DeviceName: /dev/sda1
+	        VolumeSize: 10
+	    security_groups:
+	      MyBaseSG:
+	        - IpProtocol: tcp
+	          FromPort: 22
+	          ToPort: 22
+	          # The CIDR range of the peering VPC
+	          CidrIp: 10.0.0.0/16
+	        - IpProtocol: tcp
+	          FromPort: 22
+	          ToPort: 22
+	          # This is the ext IP on the MoJD network so that we can ssh.
+	          CidrIp: 81.134.202.29/32
+	      WebServer:
+	        - IpProtocol: tcp
+	          FromPort: 80
+	          ToPort: 80
+	          SourceSecurityGroupId:
+	            Ref: DefaultSGhelloworlddev
+	      MySaltSG:
+	        - IpProtocol: tcp
+	          FromPort: 4505
+	          ToPort: 4506
+	          SourceSecurityGroupId:
+	            Ref: MyBaseSG
+	  elb:
+	    - name: helloworld-dev
+	      # This zone must exist in the AWS account you are using.
+	      hosted_zone: dsd.io.
+	      scheme: internet-facing
+	      listeners:
+	        - LoadBalancerPort: 80
+	          InstancePort: 80
+	          Protocol: tcp
+	  includes:
+	    - ./cloudformation/iam-deploy.json
+	  s3: {}
+	
+	
+	
+	dev1:
+	  master_zone: dsd.io
+	  ec2:
+	    auto_scaling:
+	      desired: 1
+	      max: 2
+	      min: 0
+	    tags:
+	      Role: docker
+	      Apps: helloworld
+	    parameters:
+	      KeyName: default
+	      InstanceType: t2.micro
+	    block_devices:
+	      - DeviceName: /dev/sda1
+	        VolumeSize: 10
+	    security_groups:
+	      MyBaseSG:
+	        - IpProtocol: tcp
+	          FromPort: 22
+	          ToPort: 22
+	          # The CIDR range of the peering VPC
+	          CidrIp: 10.128.0.0/16
+	        - IpProtocol: tcp
+	          FromPort: 22
+	          ToPort: 22
+	          # This is the ext IP on the MoJD network so that we can ssh.
+	          CidrIp: 81.134.202.29/32
+	      WebServer:
+	        - IpProtocol: tcp
+	          FromPort: 80
+	          ToPort: 80
+	          SourceSecurityGroupId:
+	            Ref: DefaultSGhelloworlddev1
+	      MySaltSG:
+	        - IpProtocol: tcp
+	          FromPort: 4505
+	          ToPort: 4506
+	          SourceSecurityGroupId:
+	            Ref: MyBaseSG
+	  elb:
+	    - name: helloworld-dev1
+	      hosted_zone: dsd.io.
+	      scheme: internet-facing
+	      listeners:
+	        - LoadBalancerPort: 80
+	          InstancePort: 80
+	          Protocol: tcp
+	  includes:
+	    - ./cloudformation/iam-deploy.json
+	 

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -10,13 +10,13 @@ from bootstrap_cfn import vpc
 class TestVPC(unittest.TestCase):
 
     @patch("bootstrap_cfn.vpc.VPC.get_vpc_route_table_ids")
-    @patch("bootstrap_cfn.vpc.VPC.get_vpc_cidr_block")
+    @patch("bootstrap_cfn.vpc.VPC.get_vpc_cidr_blocks")
     @patch("bootstrap_cfn.vpc.VPC.get_stack_vpc_id")
     @patch("bootstrap_cfn.vpc.VPC.get_stack_name_by_match")
     def test_init_stack_wildcard(self,
                                  mock_get_stack_name_by_match,
                                  mock_get_stack_vpc_id,
-                                 mock_get_vpc_cidr_block,
+                                 mock_get_vpc_cidr_blocks,
                                  mock_get_vpc_route_table_ids):
         """
         TestVPC::test_init_stack_wildcard: Test that we generate the correct config when we have a wildcard on the entire stack
@@ -37,9 +37,9 @@ class TestVPC(unittest.TestCase):
             "vpc_123",
             "peervpc_xyz"
         ]
-        mock_get_vpc_cidr_block.side_effect = [
-            "1.2.3.4/8",  # Self VPC cidr block
-            "10.11.12.13/24"  # Peer VPC cidr block
+        mock_get_vpc_cidr_blocks.side_effect = [
+            ["1.2.3.4/8"],  # Self VPC cidr block
+            ["10.11.12.13/24"]  # Peer VPC cidr block
         ]
         mock_get_vpc_route_table_ids.side_effect = [
             ["rt_abc", "rt_def"],  # All self vpc route tables
@@ -90,7 +90,7 @@ class TestVPC(unittest.TestCase):
         mock_get_stack_name_by_match.assert_called_with('peer_stack_1', min_results=1, max_results=1)
         mock_get_stack_vpc_id.assert_called_with('peer_stack_1-abc')
         # Getting the cidr block for self as its wildcarded
-        mock_get_vpc_cidr_block.assert_called_with('peervpc_xyz')
+        mock_get_vpc_cidr_blocks.assert_called_with('vpc_123')
         # Getting the route tables ids for one route on the peer only
         mock_get_vpc_route_table_ids.assert_called_with('peervpc_xyz')
         self.assertDictEqual(expected_result,
@@ -100,13 +100,13 @@ class TestVPC(unittest.TestCase):
                              % (compare(expected_result, actual_result)))
 
     @patch("bootstrap_cfn.vpc.VPC.get_vpc_route_table_ids")
-    @patch("bootstrap_cfn.vpc.VPC.get_vpc_cidr_block")
+    @patch("bootstrap_cfn.vpc.VPC.get_vpc_cidr_blocks")
     @patch("bootstrap_cfn.vpc.VPC.get_stack_vpc_id")
     @patch("bootstrap_cfn.vpc.VPC.get_stack_name_by_match")
     def test_init_source_route_table_wildcard(self,
                                               mock_get_stack_name_by_match,
                                               mock_get_stack_vpc_id,
-                                              mock_get_vpc_cidr_block,
+                                              mock_get_vpc_cidr_blocks,
                                               mock_get_vpc_route_table_ids):
         """
         TestVPC::test_init_source_route_table_wildcard: Test that we generate the correct config when we have a wildcard on the source routes
@@ -134,9 +134,9 @@ class TestVPC(unittest.TestCase):
             "vpc_123",
             "peervpc_xyz"
         ]
-        mock_get_vpc_cidr_block.side_effect = [
-            "1.2.3.4/8",  # Self VPC cidr block
-            "10.11.12.13/24"  # Peer VPC cidr block
+        mock_get_vpc_cidr_blocks.side_effect = [
+            ["1.2.3.4/8"],  # Self VPC cidr block
+            ["10.11.12.13/24"]  # Peer VPC cidr block
         ]
         mock_get_vpc_route_table_ids.side_effect = [
             ["rt_abc", "rt_def"],  # All self vpc route tables
@@ -182,13 +182,13 @@ class TestVPC(unittest.TestCase):
                              % (compare(expected_result, actual_result)))
 
     @patch("bootstrap_cfn.vpc.VPC.get_vpc_route_table_ids")
-    @patch("bootstrap_cfn.vpc.VPC.get_vpc_cidr_block")
+    @patch("bootstrap_cfn.vpc.VPC.get_vpc_cidr_blocks")
     @patch("bootstrap_cfn.vpc.VPC.get_stack_vpc_id")
     @patch("bootstrap_cfn.vpc.VPC.get_stack_name_by_match")
     def test_init_target_route_table_wildcard(self,
                                               mock_get_stack_name_by_match,
                                               mock_get_stack_vpc_id,
-                                              mock_get_vpc_cidr_block,
+                                              mock_get_vpc_cidr_blocks,
                                               mock_get_vpc_route_table_ids):
         """
          TestVPC::test_init_target_route_table_wildcard: Test that we generate the correct config when we have a wildcard on the target routes
@@ -216,8 +216,8 @@ class TestVPC(unittest.TestCase):
             "vpc_123",
             "peervpc_xyz"
         ]
-        mock_get_vpc_cidr_block.side_effect = [
-            "1.2.3.4/8",  # Self VPC cidr block
+        mock_get_vpc_cidr_blocks.side_effect = [
+            ["1.2.3.4/8"],  # Self VPC cidr block
         ]
         mock_get_vpc_route_table_ids.side_effect = [
             ["rt_def"],  # Self vpc route tables matched to rt_def
@@ -265,13 +265,13 @@ class TestVPC(unittest.TestCase):
                              % (compare(expected_result, actual_result)))
 
     @patch("bootstrap_cfn.vpc.VPC.get_vpc_route_table_ids")
-    @patch("bootstrap_cfn.vpc.VPC.get_vpc_cidr_block")
+    @patch("bootstrap_cfn.vpc.VPC.get_vpc_cidr_blocks")
     @patch("bootstrap_cfn.vpc.VPC.get_stack_vpc_id")
     @patch("bootstrap_cfn.vpc.VPC.get_stack_name_by_match")
     def test_init_cidr_block_wildcards(self,
                                        mock_get_stack_name_by_match,
                                        mock_get_stack_vpc_id,
-                                       mock_get_vpc_cidr_block,
+                                       mock_get_vpc_cidr_blocks,
                                        mock_get_vpc_route_table_ids):
         """
         TestVPC::test_init_cidr_block_wildcards: Test that we generate the correct config when we have a wildcard on the cidr blocks
@@ -283,9 +283,9 @@ class TestVPC(unittest.TestCase):
             "vpc_123",
             "peervpc_xyz"
         ]
-        mock_get_vpc_cidr_block.side_effect = [
-            "1.0.0.0/8",  # First Peer VPC cidr block
-            "2.0.0.0/8",  # Self VPC cidr block
+        mock_get_vpc_cidr_blocks.side_effect = [
+            ["1.0.0.0/8"],  # First Peer VPC cidr block
+            ["2.0.0.0/8"],  # Self VPC cidr block
         ]
         mock_get_vpc_route_table_ids.side_effect = [
             ["rt_def"],

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -1,0 +1,361 @@
+import unittest
+
+from mock import patch
+
+from testfixtures.comparison import compare
+
+from bootstrap_cfn import vpc
+
+
+class TestVPC(unittest.TestCase):
+
+    @patch("bootstrap_cfn.vpc.VPC.get_vpc_route_table_ids")
+    @patch("bootstrap_cfn.vpc.VPC.get_vpc_cidr_block")
+    @patch("bootstrap_cfn.vpc.VPC.get_stack_vpc_id")
+    @patch("bootstrap_cfn.vpc.VPC.get_stack_name_by_match")
+    def test_init_stack_wildcard(self,
+                                 mock_get_stack_name_by_match,
+                                 mock_get_stack_vpc_id,
+                                 mock_get_vpc_cidr_block,
+                                 mock_get_vpc_route_table_ids):
+        """
+        TestVPC::test_init_stack_wildcard: Test that we generate the correct config when we have a wildcard on the entire stack
+        """
+        # Peer the fill stack cidr block between all routes
+        config = {
+            "vpc": {
+                "peering": {
+                    "peer_stack_1": "*"
+                }
+            }
+        }
+
+        mock_get_stack_name_by_match.return_value = [
+            {"StackName": "peer_stack_1-abc"}
+        ]
+        mock_get_stack_vpc_id.side_effect = [
+            "vpc_123",
+            "peervpc_xyz"
+        ]
+        mock_get_vpc_cidr_block.side_effect = [
+            "1.2.3.4/8",  # Self VPC cidr block
+            "10.11.12.13/24"  # Peer VPC cidr block
+        ]
+        mock_get_vpc_route_table_ids.side_effect = [
+            ["rt_abc", "rt_def"],  # All self vpc route tables
+            ["rt_123", "rt_456", "rt_789"],  # All peering vpc route tables
+            ["rt_abc", "rt_def"],  # All self vpc route tables
+            ["rt_123", "rt_456", "rt_789"],  # All peering vpc route tables
+            None
+        ]
+
+        stack_name = "test_stack"
+
+        test_vpc = vpc.VPC(config, stack_name)
+
+        expected_result = {
+            "peer_stack_1":
+            {
+                "source_routes": {
+                    "rt_abc": {
+                        "cidr_blocks": ["1.2.3.4/8"],
+                        "route_table_id": "rt_abc"
+                    },
+                    "rt_def": {
+                        "cidr_blocks": ["1.2.3.4/8"],
+                        "route_table_id": "rt_def"
+                    }
+                },
+                "target_routes": {
+                    "rt_123": {
+                        "cidr_blocks": ["10.11.12.13/24"],
+                        "route_table_id": "rt_123"
+                    },
+                    "rt_456": {
+                        "cidr_blocks": ["10.11.12.13/24"],
+                        "route_table_id": "rt_456"
+                    },
+                    "rt_789": {
+                        "cidr_blocks": ["10.11.12.13/24"],
+                        "route_table_id": "rt_789"
+                    }
+                },
+                "vpc_id": "peervpc_xyz",
+                "stack_name": "peer_stack_1-abc"
+            }
+        }
+        actual_result = test_vpc.peering_config
+
+        # Test our calling counts
+        mock_get_stack_name_by_match.assert_called_with('peer_stack_1', min_results=1, max_results=1)
+        mock_get_stack_vpc_id.assert_called_with('peer_stack_1-abc')
+        # Getting the cidr block for self as its wildcarded
+        mock_get_vpc_cidr_block.assert_called_with('peervpc_xyz')
+        # Getting the route tables ids for one route on the peer only
+        mock_get_vpc_route_table_ids.assert_called_with('peervpc_xyz')
+        self.assertDictEqual(expected_result,
+                             actual_result,
+                             "TestVPC::test_init_stack_wildcard: "
+                             "TODO: dicts not equal %s"
+                             % (compare(expected_result, actual_result)))
+
+    @patch("bootstrap_cfn.vpc.VPC.get_vpc_route_table_ids")
+    @patch("bootstrap_cfn.vpc.VPC.get_vpc_cidr_block")
+    @patch("bootstrap_cfn.vpc.VPC.get_stack_vpc_id")
+    @patch("bootstrap_cfn.vpc.VPC.get_stack_name_by_match")
+    def test_init_source_route_table_wildcard(self,
+                                              mock_get_stack_name_by_match,
+                                              mock_get_stack_vpc_id,
+                                              mock_get_vpc_cidr_block,
+                                              mock_get_vpc_route_table_ids):
+        """
+        TestVPC::test_init_source_route_table_wildcard: Test that we generate the correct config when we have a wildcard on the source routes
+        """
+        # Peer all source route tables to the full target stacks cidr block
+        config = {
+            "vpc": {
+                "peering": {
+                    "peer_stack_1": {
+                        "source_routes": "*",
+                        "target_routes": {
+                            "rt_456": {
+                                "cidr_blocks": ["66.66.66.66/24"]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        mock_get_stack_name_by_match.return_value = [
+            {"StackName": "peer_stack_1-abc"}
+        ]
+        mock_get_stack_vpc_id.side_effect = [
+            "vpc_123",
+            "peervpc_xyz"
+        ]
+        mock_get_vpc_cidr_block.side_effect = [
+            "1.2.3.4/8",  # Self VPC cidr block
+            "10.11.12.13/24"  # Peer VPC cidr block
+        ]
+        mock_get_vpc_route_table_ids.side_effect = [
+            ["rt_abc", "rt_def"],  # All self vpc route tables
+            ["rt_456"],  # Peering vpc route tables matched to rt_456
+            ["rt_abc", "rt_def"],  # All self vpc route tables
+            ["rt_456"],  # Peering vpc route tables matched to rt_456
+            None
+        ]
+
+        stack_name = "test_stack"
+
+        test_vpc = vpc.VPC(config, stack_name)
+
+        expected_result = {
+            "peer_stack_1":
+            {
+                "source_routes": {
+                    "rt_abc": {
+                        "cidr_blocks": ["1.2.3.4/8"],
+                        "route_table_id": "rt_abc"
+                    },
+                    "rt_def": {
+                        "cidr_blocks": ["1.2.3.4/8"],
+                        "route_table_id": "rt_def"
+                    }
+                },
+                "target_routes": {
+                    "rt_456": {
+                        "cidr_blocks": ["66.66.66.66/24"],
+                        "route_table_id": "rt_456"
+                    }
+                },
+                "vpc_id": "peervpc_xyz",
+                "stack_name": "peer_stack_1-abc"
+            }
+        }
+        actual_result = test_vpc.peering_config
+
+        self.assertDictEqual(expected_result,
+                             actual_result,
+                             "TestVPC::test_init_source_route_table_wildcard: "
+                             "TODO: dicts not equal %s"
+                             % (compare(expected_result, actual_result)))
+
+    @patch("bootstrap_cfn.vpc.VPC.get_vpc_route_table_ids")
+    @patch("bootstrap_cfn.vpc.VPC.get_vpc_cidr_block")
+    @patch("bootstrap_cfn.vpc.VPC.get_stack_vpc_id")
+    @patch("bootstrap_cfn.vpc.VPC.get_stack_name_by_match")
+    def test_init_target_route_table_wildcard(self,
+                                              mock_get_stack_name_by_match,
+                                              mock_get_stack_vpc_id,
+                                              mock_get_vpc_cidr_block,
+                                              mock_get_vpc_route_table_ids):
+        """
+         TestVPC::test_init_target_route_table_wildcard: Test that we generate the correct config when we have a wildcard on the target routes
+        """
+        # Peer all target route tables to the full source stacks cidr block
+        config = {
+            "vpc": {
+                "peering": {
+                    "peer_stack_1": {
+                        "source_routes": {
+                            "rt_def": {
+                                "cidr_blocks": ["66.66.66.66/24"]
+                            }
+                        },
+                        "target_routes": "*"
+                    }
+                }
+            }
+        }
+
+        mock_get_stack_name_by_match.return_value = [
+            {"StackName": "peer_stack_1-abc"}
+        ]
+        mock_get_stack_vpc_id.side_effect = [
+            "vpc_123",
+            "peervpc_xyz"
+        ]
+        mock_get_vpc_cidr_block.side_effect = [
+            "1.2.3.4/8",  # Self VPC cidr block
+        ]
+        mock_get_vpc_route_table_ids.side_effect = [
+            ["rt_def"],  # Self vpc route tables matched to rt_def
+            ["rt_123", "rt_456", "rt_789"],  # All peering vpc route tables
+            None
+        ]
+
+        stack_name = "test_stack"
+
+        test_vpc = vpc.VPC(config, stack_name)
+
+        expected_result = {
+            "peer_stack_1":
+            {
+                "source_routes": {
+                    "rt_def": {
+                        "cidr_blocks": ["66.66.66.66/24"],
+                        "route_table_id": "rt_def"
+                    }
+                },
+                "target_routes": {
+                    "rt_123": {
+                        "cidr_blocks": ["1.2.3.4/8"],
+                        "route_table_id": "rt_123"
+                    },
+                    "rt_456": {
+                        "cidr_blocks": ["1.2.3.4/8"],
+                        "route_table_id": "rt_456"
+                    },
+                    "rt_789": {
+                        "cidr_blocks": ["1.2.3.4/8"],
+                        "route_table_id": "rt_789"
+                    }
+                },
+                "vpc_id": "peervpc_xyz",
+                "stack_name": "peer_stack_1-abc"
+            }
+        }
+        actual_result = test_vpc.peering_config
+
+        self.assertDictEqual(expected_result,
+                             actual_result,
+                             "TestVPC::test_init_target_route_table_wildcard: "
+                             "TODO: dicts not equal %s"
+                             % (compare(expected_result, actual_result)))
+
+    @patch("bootstrap_cfn.vpc.VPC.get_vpc_route_table_ids")
+    @patch("bootstrap_cfn.vpc.VPC.get_vpc_cidr_block")
+    @patch("bootstrap_cfn.vpc.VPC.get_stack_vpc_id")
+    @patch("bootstrap_cfn.vpc.VPC.get_stack_name_by_match")
+    def test_init_cidr_block_wildcards(self,
+                                       mock_get_stack_name_by_match,
+                                       mock_get_stack_vpc_id,
+                                       mock_get_vpc_cidr_block,
+                                       mock_get_vpc_route_table_ids):
+        """
+        TestVPC::test_init_cidr_block_wildcards: Test that we generate the correct config when we have a wildcard on the cidr blocks
+        """
+        mock_get_stack_name_by_match.return_value = [
+            {"StackName": "peer_stack_1-abc"}
+        ]
+        mock_get_stack_vpc_id.side_effect = [
+            "vpc_123",
+            "peervpc_xyz"
+        ]
+        mock_get_vpc_cidr_block.side_effect = [
+            "1.0.0.0/8",  # First Peer VPC cidr block
+            "2.0.0.0/8",  # Self VPC cidr block
+        ]
+        mock_get_vpc_route_table_ids.side_effect = [
+            ["rt_def"],
+            ["rt_abc"],
+            ["rt_456"],
+            ["rt_123"],
+            None
+        ]
+        # Peer all source/target cidr blocks to specific tables
+        config = {
+            "vpc": {
+                "peering": {
+                    "peer_stack_1": {
+                        "source_routes": {
+                            "rt_abc": {
+                                "cidr_blocks": ["1.2.3.4/16", "5.6.7.8/16"],
+                            },
+
+                            "rt_def": {
+                                "cidr_blocks": "*"
+                            }
+                        },
+                        "target_routes": {
+                            "rt_123": {
+                                "cidr_blocks": ["2.2.3.4/16"],
+                            },
+                            "rt_456": {
+                                "cidr_blocks": "*"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        stack_name = "test_stack"
+
+        test_vpc = vpc.VPC(config, stack_name)
+
+        expected_result = {
+            "peer_stack_1":
+            {
+                "source_routes": {
+                    "rt_abc": {
+                        "cidr_blocks": ["1.2.3.4/16", "5.6.7.8/16"],
+                        "route_table_id": "rt_abc"
+                    },
+                    "rt_def": {
+                        "cidr_blocks": ["1.0.0.0/8"],
+                        "route_table_id": "rt_def"
+                    }
+                },
+                "target_routes": {
+                    "rt_123": {
+                        "cidr_blocks": ["2.2.3.4/16"],
+                        "route_table_id": "rt_123"
+                    },
+                    "rt_456": {
+                        "cidr_blocks": ["2.0.0.0/8"],
+                        "route_table_id": "rt_456"
+                    }
+                },
+                "vpc_id": "peervpc_xyz",
+                "stack_name": "peer_stack_1-abc"
+            }
+        }
+        actual_result = test_vpc.peering_config
+
+        self.assertDictEqual(expected_result,
+                             actual_result,
+                             "TestVPC::test_init_stack_wildcard: "
+                             "TODO: dicts not equal %s"
+                             % (compare(expected_result, actual_result)))


### PR DESCRIPTION
Add advanced settings and wildcards for peering vpcs

```
* Create new class VPC to handle vpc connections and peering
* Update requirements to include boto3
* Add new fab tasks enable/disable_vpc_peering
* Add boto3 to setup.py requirements
* Add VPC docs page
* Add vpc requester/accepter routes to all route tables in each vpc

* Allow per route table cidr block specification
* Add option to wildcard the entire stack. Making all routes
and cidr ranges peered between the 2 stacks
* Add option to wildcard source or target route tables meaning that
all route tables will have the specified cidr block route applied
* Add option to wildcard a cidr block so that the specified route
table will have all the target stacks cidr block range applied to
it
```
