### PR TITLE
Fix certificate updating on live elbs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -284,8 +284,6 @@ By default the ELBs will have a security group opening them to the world on 80 a
 
 If you set the protocol on an ELB to HTTPS you must include a key called ``certificate_name`` in the ELB block (as example above) and matching cert data in a key with the same name as the cert under ``ssl`` (see example above). The ``cert`` and ``key`` are required and the ``chain`` is optional.
 
-The certificate will be uploaded before the stack is created and removed after it is deleted.
-
 It is possilbe to define a custom health check for an ELB like follows::
 
     health_check:
@@ -294,6 +292,20 @@ It is possilbe to define a custom health check for an ELB like follows::
       Target: HTTP:80/ping.json
       Timeout: 5
       UnhealthyThreshold: 2
+
+ELB Certificates
+~~~~~~~~~~~~~~~~
+
+The SSL certificate will be uploaded before the stack is created and removed after it is deleted.
+To update the SSL certificate on ELB listeners run the fab task below, this uploads and updates the
+certificate on each HTTPS listener on your ELBs, by default the old certificate is deleted.
+
+.. code:: bash
+
+   fab load_env:<env_data> update_certs
+
+Note that some errors appear in the log due to the time taken for AWS changes to propogate across infrastructure
+elements, these are handled internally and are not neccessarily a sign of failure.
 
 ELB Policies
 ~~~~~~~~~~~~

--- a/bootstrap_cfn/cloudformation.py
+++ b/bootstrap_cfn/cloudformation.py
@@ -61,7 +61,7 @@ class Cloudformation:
                 load balancers for this stack
         """
         resource_type = 'AWS::ElasticLoadBalancing::LoadBalancer'
-        return self.get_resource_type(stack_name_or_id, resource_type)
+        return get_resource_type(stack_name_or_id, resource_type)
 
 
 def get_resource_type(stack_name_or_id,

--- a/bootstrap_cfn/elb.py
+++ b/bootstrap_cfn/elb.py
@@ -1,8 +1,15 @@
 import logging
 
+import time
+
 import boto.ec2.elb
 
+from boto.exception import BotoServerError
+
+import boto.iam
+
 from bootstrap_cfn import cloudformation, iam, utils
+
 from bootstrap_cfn.errors import BootstrapCfnError, CloudResourceNotFoundError
 
 
@@ -24,31 +31,35 @@ class ELB:
             aws_profile_name, aws_region_name
         )
 
-    def set_ssl_certificates(self, ssl_config, stack_name):
+    def set_ssl_certificates(self, cert_names, stack_name, max_retries=1, retry_delay=10):
         """
         Look for SSL listeners on all the load balancers connected to
-        this stack, then set update the certificate to that of the config
+        this stack, then set update the certificate to that of the config.
+        We can retry with delay, default is to only try once.
 
         Args:
             ssl_config (dictionary): Certification names to corresponding data
             stack_name (string): Name of the stack
+            max_retries(int): The number of retries to carry out on the operation
+            retry_delay(int): The retry delay of the operation
 
         Returns:
-            list: The list of load balancers that were affected by the change
+            list: The list of the certificates that were replaced
 
         Raises:
             CloudResourceNotFoundError: Raised when the load balancer key in the cloud
                 config is not found
         """
-        updated_load_balancers = []
-        for cert_name in ssl_config.keys():
+        # List of all certificates replaced
+        replaced_certificates = []
+        for cert_name in cert_names:
             # Get the cert id and also its arn
             cert_id = "{0}-{1}".format(cert_name, stack_name)
             cert_arn = self.iam.get_arn_for_cert(cert_id)
 
             # Get all stack load balancers
             load_balancer_resources = self.cfn.get_stack_load_balancers(stack_name)
-            found_load_balancer_names = [lb.physical_resource_id for lb in load_balancer_resources]
+            found_load_balancer_names = [lb["PhysicalResourceId"] for lb in load_balancer_resources]
             # Use load balancer names to filter getting load balancer details
             load_balancers = []
             if len(found_load_balancer_names) > 0:
@@ -60,8 +71,7 @@ class ELB:
                 for load_balancer in load_balancers:
                     for listener in load_balancer.listeners:
                         # Get protocol, if https, update cert
-                        # in_port = listener[0]
-                        out_port = listener[1]
+                        in_port = listener[0]
                         protocol = listener[2]
                         # If the protocol is HTTPS then set the cert on the listener
                         if protocol == "HTTPS":
@@ -69,12 +79,37 @@ class ELB:
                                          "Found HTTPS protocol on '%s', "
                                          "updating SSL certificate with '%s'"
                                          % (load_balancer.name, cert_arn))
-                            self.conn_elb.set_lb_listener_SSL_certificate(load_balancer.name,
-                                                                          out_port,
-                                                                          cert_arn
-                                                                          )
-                            updated_load_balancers.append(load_balancer)
+                            # Get current listener certificate arn
+                            previous_cert_arn = None
+                            lb = self.conn_elb.get_all_load_balancers(load_balancer.name)[0]
+                            for listener in lb.listeners:
+                                # We're looking for a tuple of the form (443, 80, 'HTTPS', 'HTTP', <cert_arn>)
+                                if 'HTTPS' in listener.get_tuple():
+                                    previous_cert_arn = listener[4]
+                            # Set the current certificate on the listener to the new one
+                            retries = 0
+                            while retries < max_retries:
+                                retries += 1
+                                try:
+                                    self.conn_elb.set_lb_listener_SSL_certificate(load_balancer.name,
+                                                                                  in_port,
+                                                                                  cert_arn)
+                                    if previous_cert_arn:
+                                        previous_cert_name = previous_cert_arn.split('/')[1].split("-%s" % stack_name)[0]
+                                        replaced_certificates.append(previous_cert_name)
 
+                                    logging.info("update_certs:Successfully set ssl cert to '%s', "
+                                                 " replacing cert '%s'"
+                                                 % (cert_arn, previous_cert_name))
+
+                                    break
+                                except BotoServerError as e:
+                                    logging.warning("update_certs: Cannot set ssl certs, reason '%s', "
+                                                    "waiting %s seconds on retry %s/%s"
+                                                    % (e.error_message, retry_delay, retries, max_retries))
+                                    # Only sleep if we're going to try again
+                                    if retries < max_retries:
+                                        time.sleep(retry_delay)
             else:
                 # Throw key error. There being no load balancers to update is not
                 # necessarily a problem but since the caller expected there to be let
@@ -82,7 +117,7 @@ class ELB:
                 raise CloudResourceNotFoundError("ELB::set_ssl_certificates: "
                                                  "No load balancers found in stack,")
 
-        return updated_load_balancers
+        return replaced_certificates
 
     def list_domain_names(self, stack_name):
         """

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -138,38 +138,6 @@ class TestIAM(unittest.TestCase):
                          "Should be able update certs"
                          )
 
-    @raises(CloudResourceNotFoundError)
-    @patch("boto.iam.IAMConnection.delete_server_cert")
-    @patch("boto.iam.IAMConnection.upload_server_cert")
-    @patch("bootstrap_cfn.iam.IAM.get_remote_certificate")
-    def test_update_ssl_certificates_not_exist(self,
-                                               mock_get_remote_certificate,
-                                               mock_upload_server_cert,
-                                               mock_delete_server_cert):
-        """
-        Test we cause an exception trying update over
-        non existing certificates
-        """
-        mock_get_remote_certificate.side_effect = [True,
-                                                   False,
-                                                   False,
-                                                   None]
-        mock_upload_server_cert.side_effect = [self.successful_response,
-                                               self.unsuccessful_response,
-                                               None]
-        mock_delete_server_cert.side_effect = [self.successful_response,
-                                               self.unsuccessful_response,
-                                               None]
-        ssl_config = self.test_certs
-        stack_name = "test_stack"
-        update_count = self.mock_iam.update_ssl_certificates(ssl_config,
-                                                             stack_name)
-        self.assertEqual(update_count,
-                         1,
-                         "TestIAM::test_update_ssl_certificates_force: "
-                         "Should only be able to update existing certificates "
-                         )
-
     @patch("boto.iam.IAMConnection.upload_server_cert")
     @patch("bootstrap_cfn.iam.IAM.get_remote_certificate")
     def test_upload_certificate_not_exists(self,
@@ -228,11 +196,9 @@ class TestIAM(unittest.TestCase):
         mock_delete_server_cert.return_value = self.successful_response
         cert_name = "cert1"
         stack_name = "test_stack"
-        ssl_data = self.test_certs["test_cert_1"]
 
         success = self.mock_iam.delete_certificate(cert_name,
-                                                   stack_name,
-                                                   ssl_data)
+                                                   stack_name)
         mock_get_remote_certificate.assert_called_once_with(cert_name,
                                                             stack_name)
         self.assertTrue(success,
@@ -252,11 +218,8 @@ class TestIAM(unittest.TestCase):
         mock_delete_server_cert.return_value = self.unsuccessful_response
         cert_name = "cert1"
         stack_name = "test_stack"
-        ssl_data = self.test_certs["test_cert_1"]
-
         success = self.mock_iam.delete_certificate(cert_name,
-                                                   stack_name,
-                                                   ssl_data)
+                                                   stack_name)
         mock_get_remote_certificate.assert_called_once_with(cert_name,
                                                             stack_name)
         self.assertFalse(success,


### PR DESCRIPTION
Fix certificate updating on live elbs

```
AWS wont let us update out certs when ELBs are using them so to allow
for dynamic updates we follow the logic,
- go through all the ELBs listeners looking for https connections
- save the current cert ssl name
- replace the cert ssl with a uniquesly timestamped
- optionally delete the previous ssl

Note that AWS can take time to propogate changes, so even when they
appear to be done, we need to apply retry loops and delays to make
sure they have been applied across all AWS infrastructure and not
exiting prematurely.
```
