### PR TITLE
Remove the fallback when route53 stack name is missing

### DIFF
--- a/bootstrap_cfn/errors.py
+++ b/bootstrap_cfn/errors.py
@@ -34,5 +34,20 @@ class ProfileNotFoundError(BootstrapCfnError):
         )
 
 
+class ZoneIDNotFoundError(BootstrapCfnError):
+    def __init__(self, zone_name):
+        msg = ("Could not find a zone id for zone name '{}'."
+               "Please check that this hosted zone exists "
+               "and is in the account you've specified".format(zone_name))
+        super(ZoneIDNotFoundError, self).__init__(msg)
+
+
+class ZoneRoute53RecordNotFoundError(BootstrapCfnError):
+    def __init__(self, zone_name, zone_id):
+        msg = ("Could not find an AWS Route53 record for zone name '{}' with zone id '{}'. "
+               "Please check that this record exists in the account you've specified".format(zone_name, zone_id))
+        super(ZoneRoute53RecordNotFoundError, self).__init__(msg)
+
+
 class CloudResourceNotFoundError(BootstrapCfnError):
     pass


### PR DESCRIPTION
get_stack_name uses fallback name of <application>-<environment>
when route53 lookup fails. This was done for backwards compatibility
reasons. Unfortunately, this has the side effect of masking any
route53 stack_name lookup error, which all new stacks should have.

This change will raise errors if the stack name lookup fails
rather than attempt a fallback name, this name is only useful in
the case of very old stacks that created stacks with this style of
name.

(Closes #170)
