### PR TITLE
Fix autoscale get_all_groups paging

### DIFF
--- a/bootstrap_cfn/autoscale.py
+++ b/bootstrap_cfn/autoscale.py
@@ -12,7 +12,7 @@ class Autoscale:
         self.conn_asg = utils.connect_to_aws(boto.ec2.autoscale, self)
 
     def set_autoscaling_group(self, name):
-        for grp in self.conn_asg.get_all_groups():
+        for grp in self.get_all_autoscaling_groups():
             for tag in grp.tags:
                 if tag.key == 'aws:cloudformation:stack-name':
                     if str(tag.value) == str(name):
@@ -29,3 +29,20 @@ class Autoscale:
             self.conn_asg.create_or_update_tags([tag])
             print "Created ASG Tag: Tag({0}, {1})".format(key, value)
             return True
+
+    def get_all_autoscaling_groups(self):
+        """
+        Get all the auto-scaling groups in this connection
+        Handle the pagination of results to make sure we get them all
+
+        Returns:
+            (list): A list of ASGs found
+        """
+        # Queries are paginated, while the results returned are truncated,
+        # and we dont have a key_id, keep getting pages
+        response = self.conn_asg.get_all_groups()
+        all_asgs = response
+        while response.next_token:
+            response = self.conn_asg.get_all_groups(next_token=response.next_token)
+            all_asgs += response
+        return all_asgs

--- a/tests/test_autoscale.py
+++ b/tests/test_autoscale.py
@@ -4,6 +4,7 @@ import unittest
 
 import boto.ec2.autoscale
 from boto.ec2.autoscale.group import AutoScalingGroup
+from boto.resultset import ResultSet
 
 import mock
 
@@ -12,7 +13,7 @@ from bootstrap_cfn import autoscale
 
 def get_all_groups(names=None, max_records=None, next_token=None):
 
-    groups = []
+    groups = ResultSet()
 
     for i in xrange(1, 3):
         tags = [
@@ -26,7 +27,7 @@ def get_all_groups(names=None, max_records=None, next_token=None):
         asg.name = 'test{0}'.format(i)
         asg.tags = tags
         groups.append(asg)
-
+        groups.next_token = None
     return groups
 
 


### PR DESCRIPTION
The call to boto::autoscale:get_all_groups implements paging,
this change makes sure that we don't stop at the default 50
limit, but actually get all the groups.
