### PR TITLE
Separate get and set_stack name

### DIFF
--- a/bootstrap_cfn/errors.py
+++ b/bootstrap_cfn/errors.py
@@ -49,5 +49,12 @@ class ZoneRoute53RecordNotFoundError(BootstrapCfnError):
         super(ZoneRoute53RecordNotFoundError, self).__init__(msg)
 
 
+class DNSRecordNotFoundError(BootstrapCfnError):
+    def __init__(self, zone_name):
+        msg = ("Could not find a dns record for zone name '{}'. "
+               "Please check that this record exists".format(zone_name))
+        super(DNSRecordNotFoundError, self).__init__(msg)
+
+
 class CloudResourceNotFoundError(BootstrapCfnError):
     pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Fabric==1.10.1
 PyYAML==3.11
 boto==2.36.0
 boto3==1.2.2
+dnspython==1.12.0
 mock==1.0.1
 netaddr==0.7.18
 testfixtures==4.1.2

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'PyYAML>=3.11',
         'boto>=2.36.0',
         'boto3>=1.2.2',
+        'dnspython>=1.12.0',
         'netaddr>=0.7.18',
         'troposphere>=1.0.0',
     ],


### PR DESCRIPTION
The get and set stack name functionality is combined into one
command at the moment. This means that a boto route53 connection
is required, even if we only need to fetch a public address to get
the stack name. This change uses separates the functions so that
dnspythons resolver can be used to fetch the stack name record,
meaning that no AWS credentials are required. set_stack_name uses
the same boto.route53 method as before to create stack name records.

 # Please enter the commit message for your changes. Lines starting
