### PR TITLE
Fix passing ssl_data as max_retries value to delete_certificate

### DIFF
--- a/bootstrap_cfn/iam.py
+++ b/bootstrap_cfn/iam.py
@@ -34,8 +34,7 @@ class IAM:
     def delete_ssl_certificate(self, ssl_config, stack_name):
         for cert_name, ssl_data in ssl_config.items():
             self.delete_certificate(cert_name,
-                                    stack_name,
-                                    ssl_data)
+                                    stack_name)
         return True
 
     def update_ssl_certificates(self, ssl_config, stack_name):


### PR DESCRIPTION
delete_ssl_certificate is passing ssl_data as the third argument
to its call to delete certificate, accidentally setting the
max_retries value instead. This means that the delete_certificate
call would retry many, many times.

This change drops the erroneous argument.

(closes #181)
