### PR TITLE
Add automatic upgrades to cloud-init.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,10 @@ The ``ec2`` key configures the EC2 instances created by auto-scaling groups (ASG
     Maximum number of instances to scale up to
   ``min``
     Minimum number of instances to maintain.
+  ``health_check_grace_period``
+    Seconds before running the healthcheck on an instance. Default 300
+  ``health_check_type``
+    Use EC2 or ELB healthcheck types. Default EC2
 
   Example::
 
@@ -125,6 +129,8 @@ The ``ec2`` key configures the EC2 instances created by auto-scaling groups (ASG
           desired: 1
           max: 3
           min: 0
+          health_check_grace_period: 360
+          health_check_type: ELB
 
 :``tags``:
   A dictionary of tag name to value to apply to all instances of the ASG. Note that the environment you select via ``fab aws`` will be applied as a tag with a name of ``Env``.

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -1072,7 +1072,7 @@ class ConfigParser(object):
             os_data(dict): Dictionary of OS data in the form
                 {
                     'name': 'ubuntu-1404',
-                    'ami': 'ami-00d88f77',
+                    'ami': 'ami-464af835',
                     'region': 'eu-west-1',
                     'distribution': 'ubuntu',
                     'type': 'linux',
@@ -1087,7 +1087,7 @@ class ConfigParser(object):
         available_types = {
             'ubuntu-1404': {
                 'name': 'ubuntu-1404',
-                'ami': 'ami-00d88f77',
+                'ami': 'ami-464af835',
                 'region': 'eu-west-1',
                 'distribution': 'ubuntu',
                 'type': 'linux',

--- a/bootstrap_cfn/errors.py
+++ b/bootstrap_cfn/errors.py
@@ -58,3 +58,10 @@ class DNSRecordNotFoundError(BootstrapCfnError):
 
 class CloudResourceNotFoundError(BootstrapCfnError):
     pass
+
+
+class OSTypeNotFoundError(BootstrapCfnError):
+    def __init__(self, type, available_types):
+        msg = ("The os type '{}' is not recognised, should be one of {}. "
+               .format(type, available_types))
+        super(OSTypeNotFoundError, self).__init__(msg)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1384,9 +1384,10 @@ class TestConfigParser(unittest.TestCase):
         with patch.object(config, 'get_hostname_boothook', return_value={"content": "sentinel"}) as mock_boothook:
             user_data_parts = config.get_ec2_userdata()
             mock_boothook.assert_called_once_with(data['ec2'])
-
-            compare(yaml.load(user_data_parts[1]['content']), data['ec2']['cloud_config'])
-            compare(user_data_parts[0]['content'], 'sentinel')
+            # We have linux, so we put package update data in first
+            compare(user_data_parts[0]['content'], '{package_reboot_if_required: true, package_update: true, package_upgrade: true}\n')
+            compare(user_data_parts[1]['content'], 'sentinel')
+            compare(yaml.load(user_data_parts[2]['content']), data['ec2']['cloud_config'])
 
     def test_get_ec2_userdata_no_cloud_config(self):
         # If there is no cloud config we should get a default
@@ -1399,9 +1400,10 @@ class TestConfigParser(unittest.TestCase):
         with patch.object(config, 'get_hostname_boothook', return_value={"content": "sentinel"}) as mock_boothook:
             user_data_parts = config.get_ec2_userdata()
             mock_boothook.assert_called_once_with(data['ec2'])
-
-            compare(yaml.load(user_data_parts[1]['content']), {'manage_etc_hosts': True})
-            compare(user_data_parts[0]['content'], 'sentinel')
+            # We have linux, so we put package update data in first
+            compare(user_data_parts[0]['content'], '{package_reboot_if_required: true, package_update: true, package_upgrade: true}\n')
+            compare(user_data_parts[1]['content'], 'sentinel')
+            compare(yaml.load(user_data_parts[2]['content']), {'manage_etc_hosts': True})
 
     def test_get_hostname_boothook(self):
         config = ConfigParser({}, environment="env", application="test", stack_name="my-stack")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -757,7 +757,7 @@ class TestConfigParser(unittest.TestCase):
 
         mappings = cfn_template['Mappings']
         expected = {
-            'AWSRegion2AMI': {'eu-west-1': {'AMI': 'ami-00d88f77'}},
+            'AWSRegion2AMI': {'eu-west-1': {'AMI': 'ami-464af835'}},
             'SubnetConfig': {
                 'VPC': {
                     'CIDR': '10.0.0.0/16',
@@ -820,7 +820,7 @@ class TestConfigParser(unittest.TestCase):
 
         mappings = cfn_template['Mappings']
         expected = {
-            'AWSRegion2AMI': {'eu-west-1': {'AMI': 'ami-00d88f77'}},
+            'AWSRegion2AMI': {'eu-west-1': {'AMI': 'ami-464af835'}},
             'SubnetConfig': {
                 'VPC': {
                     'CIDR': '172.22.0.0/16',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1265,6 +1265,8 @@ class TestConfigParser(unittest.TestCase):
             VPCZoneIdentifier=[Ref("SubnetA"), Ref("SubnetB"), Ref("SubnetC")],
             LaunchConfigurationName=Ref("BaseHostLaunchConfig"),
             AvailabilityZones=GetAZs(""),
+            HealthCheckGracePeriod=300,
+            HealthCheckType='EC2'
         )
 
         BaseHostSG = SecurityGroup(


### PR DESCRIPTION
Add automatic upgrades to cloud-init.

This change adds in automatic package upgrades to user data for
instances when we are using linux AMIs.
- Add some default user data to have updates on boot on Linux AMIs
  by default
- Allow the ASG config to use ELB healthchecks
- Upgrade ubuntu AMI to latest 14.04
- Update ami in tests
- Update expected user data in tests
