### PR TITLE
Add a Name tag to instances

### DIFF
--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -1021,6 +1021,9 @@ class ConfigParser(object):
         # Allow deprecation of tags
         ec2_tags = []
         deprecated_tags = ["Env"]
+        # Add a name tag for easy ec2 instance identification in the AWS console
+        ec2_tags.append(self._get_default_resource_name_tag(type="ec2"))
+        # Get all tags from the config
         for k, v in data['tags'].items():
             if k not in deprecated_tags:
                 ec2_tags.append(Tag(k, v, True))
@@ -1121,3 +1124,16 @@ class ConfigParser(object):
         if not available_types.get(os_choice, False):
             raise errors.OSTypeNotFoundError(self.data['ec2']['os'], available_types.keys())
         return available_types.get(os_choice)
+
+    def _get_default_resource_name_tag(self, type):
+        """
+        Get the name tag we will use for ec2 instances
+
+        Returns:
+            name_tag(string): The Name: tag to use.
+            type(string): The type of the resource
+        """
+        # Use the stack name as the tag
+        value = Join("", [{"Ref": "AWS::StackName"}, "-", type])
+        name_tag = Tag("Name", value, True)
+        return name_tag

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1253,6 +1253,7 @@ class TestConfigParser(unittest.TestCase):
         self.maxDiff = None
 
         tags = [
+            ('Name', {u'Fn::Join': [u'', [{u'Ref': u'AWS::StackName'}, u'-', u'ec2']]}),
             ('Role', 'docker'),
             ('Apps', 'test'),
         ]


### PR DESCRIPTION
Add a Name tag to instances

The AWS console uses the Name tag on instances in its display. This
change sets this tag to the stack name to help identification when
viewing instances through the AWS console. The default format
for the resource Name key is,
`<application>-<environment>-<stack_hash>-<resource_type>`
