### PR TITLE
Add simple countdown for long waits

### DIFF
--- a/bootstrap_cfn/autoscale.py
+++ b/bootstrap_cfn/autoscale.py
@@ -1,7 +1,5 @@
 import logging
 
-import time
-
 import boto.ec2.autoscale
 
 import boto3
@@ -97,7 +95,7 @@ class Autoscale:
 
             # wait for the same time as the "HealthCheckGracePeriod" in the ASG
             logging.getLogger("bootstrap-cfn").info("Waiting %ss - HealthCheckGracePeriod" % health_check_grace_period)
-            time.sleep(health_check_grace_period)
+            utils.sleep_countdown(health_check_grace_period)
             logging.getLogger("bootstrap-cfn").info("End of waiting period")
 
             # check if the number of healthy instances is = to the number of expected instances, where
@@ -119,7 +117,7 @@ class Autoscale:
                                                     .format(current_instance_id, termination_delay))
             if termination_delay:
                 logging.getLogger("bootstrap-cfn").info("Waiting %ss - termination_delay" % termination_delay)
-                time.sleep(termination_delay)
+                utils.sleep_countdown(termination_delay)
                 logging.getLogger("bootstrap-cfn").info("End of waiting period")
             client.terminate_instance_in_auto_scaling_group(
                 InstanceId=current_instance_id,
@@ -175,7 +173,7 @@ class Autoscale:
                                                     .format(retry_delay, count, retry_max))
             if count == retry_max:
                 raise AutoscalingInstanceCountError(self.group.name, expected_instance_count, instances)
-            time.sleep(retry_delay)
+            utils.sleep_countdown(retry_delay)
             instances = self.get_healthy_instances()
         logging.getLogger("bootstrap-cfn").info("wait_for_instances: Found {} instances, {}"
                                                 .format(len(instances), [instance.get('InstanceId') for instance in instances]))

--- a/bootstrap_cfn/utils.py
+++ b/bootstrap_cfn/utils.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 
 from copy import deepcopy
@@ -134,3 +135,19 @@ def get_events(stack, stack_name):
         next = events.next_token
         time.sleep(1)
     return reversed(sum(event_list, []))
+
+
+def sleep_countdown(sleep_time):
+    """
+    Simple terminal countdown of the form mm:ss
+
+    Args:
+        sleep_time(int): The number of seconds to countdown from.
+    """
+    while sleep_time > 0:
+        mins, secs = divmod(sleep_time, 60)
+        timeformat = '{:02d}:{:02d}'.format(mins, secs)
+        sys.stdout.write("{}\r".format(timeformat))
+        sys.stdout.flush()
+        time.sleep(1)
+        sleep_time -= 1


### PR DESCRIPTION
When we're waiting long periods for events, such as in the case of
an autoscaling event, this change will add the disaply of a simple
countdown so we don't look unresponsive.
