### PR TITLE
Set boto3 to use aws profile session

### DIFF
--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -6,6 +6,8 @@ import sys
 import time
 import uuid
 
+import boto3
+
 import dns.resolver
 
 from fabric.api import env, task
@@ -58,6 +60,8 @@ def aws(profile_name):
         variable to
     """
     env.aws = str(profile_name).lower()
+    # Setup boto so we actually use this environment
+    boto3.setup_default_session(profile_name=env.aws)
 
 
 @task


### PR DESCRIPTION
This change sets the default boto3 session to use the aws profile
and credentials that we specify on the command line. Whenever we
set the fabric env.aws we will now also change the boto3 default
session to reflect that.
