### PR TITLE
Override AMI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,8 +162,18 @@ The ``ec2`` key configures the EC2 instances created by auto-scaling groups (ASG
           KeyName: default
           InstanceType: t2.micro
 
+:``ami``:
+  Selects which AWS AMI to use. This can be a AWS-provided AMI, a community one, or one which exists under the account in which you're building the stack. The ``ami-`` prefix is required. If not specified then a suitable default will be chosen for the ``os`` in use. If this value is present then it is recommended to specify the ``os`` too, so that other areas of the cloud formation template are correctly generated.
+
+  Example::
+
+    dev:
+      ec2:
+        ami: ami-7943ec0a
+        os: windows2012
+
 :``os``:
-  Which operating system to use.  In reality this simply selects which AMI to use. Only 1 value is recognised, namely ``windows2012`` which selects that OS. Any other value (or a missing value) results in a default of Ubuntu 14.04 LTS.
+  Which operating system to use.  This selects a default AMI and also builds relevant user_data for use by instances when spun up by the ASG. Only 2 values are recognised: ``windows2012`` and ``ubuntu-1404``. The default is ``ubuntu-1404``.  If you wish to specify an AMI manually then use ``ami`` in addition.
 
   Example::
 

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -1113,7 +1113,7 @@ class ConfigParser(object):
             },
             'windows2012': {
                 'name': 'windows2012',
-                'ami': 'ami-7943ec0a',
+                'ami': 'ami-8519a9f6',
                 'region': 'eu-west-1',
                 'distribution': 'windows',
                 'type': 'windows',

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -1123,7 +1123,13 @@ class ConfigParser(object):
         os_choice = self.data['ec2'].get('os', os_default)
         if not available_types.get(os_choice, False):
             raise errors.OSTypeNotFoundError(self.data['ec2']['os'], available_types.keys())
-        return available_types.get(os_choice)
+        os_data = available_types.get(os_choice)
+        ami = self.data['ec2'].get('ami')
+        if ami:
+            logging.info('** Using override AMI of ' + str(ami))
+            os_data['ami'] = ami
+            logging.info('overridden os data is: ' + repr(os_data))
+        return os_data
 
     def _get_default_resource_name_tag(self, type):
         """

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -840,6 +840,19 @@ class TestConfigParser(unittest.TestCase):
         config = ConfigParser(project_config.config, 'my-stack-name')
         config.process()
 
+    def test_ami_overrides_os_default(self):
+        self.maxDiff = None
+        project_config = ProjectConfig(
+                'tests/sample-project.yaml',
+                'dev',
+                'tests/sample-project-passwords.yaml')
+
+        project_config.config['ec2']['ami'] = 'ami-0000000000'
+        project_config.config['ec2']['os'] = 'windows2012'
+        config = ConfigParser(project_config.config, 'my-stack-name')
+        cfn_template = json.loads(config.process())
+        compare(cfn_template['Mappings']['AWSRegion2AMI'], {'eu-west-1': {'AMI': 'ami-0000000000'}})
+
     def test_elb_missing_cert(self):
 
         self.maxDiff = None


### PR DESCRIPTION
- Provide the ability to override the AMI used
- Use the AWS Windows 2012 R2 AMI instead of RTM
