### PR TITLE
Setup boto3 default session with default region

### DIFF
--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -63,7 +63,8 @@ def aws(profile_name):
     """
     env.aws = str(profile_name).lower()
     # Setup boto so we actually use this environment
-    boto3.setup_default_session(profile_name=env.aws)
+    boto3.setup_default_session(profile_name=env.aws,
+                                region_name=env.aws_region)
 
 
 @task

--- a/tests/test_fab_tasks.py
+++ b/tests/test_fab_tasks.py
@@ -1,6 +1,9 @@
 import unittest
 
 from bootstrap_cfn import fab_tasks  # noqa
+from mock import patch, Mock  # noqa
+
+fake_profile = {'lol': {'aws_access_key_id': 'secretz', 'aws_secret_access_key': 'verysecretz'}}
 
 
 class TestFabTasks(unittest.TestCase):
@@ -8,3 +11,8 @@ class TestFabTasks(unittest.TestCase):
     def test_loaded(self):
         # Not a great test, but it at least checks for syntax erros in the file
         pass
+
+    @patch('botocore.session.Session.get_scoped_config')
+    def test_aws_task(self, mock_botocore):
+        mock_botocore.return_value = fake_profile['lol']
+        fab_tasks.aws('nonexistent_profile')


### PR DESCRIPTION
Reason this is useful is because the workaround would be to specify for each of the aws profiles a separate entry in `~/.aws/config` in the format of: 

```
[profile profile_name]
aws_region = eu-west-1
```

With this change it will pick up the default region from "env", which is setdefault to "eu-west-1"
