### PR TITLE
Fixes exit_maintenance error

### DIFF
--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -256,8 +256,17 @@ def exit_maintenance(dry_run=False):
     # filter on the next step
     # Note: if stack does not exist this will throw a BotoServerError
     stack_elbs = dict([
-        (x.logical_resource_id, x.physical_resource_id)
+        (x.get('logical_resource_id', x.get('LogicalResourceId', None)),
+         x.get('physical_resource_id', x.get('PhysicalResourceId', None)))
         for x in elb_conn.cfn.get_stack_load_balancers(stack_name)])
+    if None in stack_elbs.keys():
+        raise BootstrapCfnError(
+            "Unable to retrieve logical resource IDs for a stack load balancer.\n"
+            "ELB Dict: ".format(stack_elbs))
+    if None in stack_elbs.values():
+        raise BootstrapCfnError(
+            "Unable to retrieve physical resource IDs for a stack load balancer.\n"
+            "ELB Dict: ".format(stack_elbs))
 
     # filter stack related load balancers (as opposed to all stack elbs in the account)
     full_load_balancers = elb_conn.conn_elb.get_all_load_balancers(


### PR DESCRIPTION
Latest bootstrap-cfn break exit_maintenance task with the following error:

```
Traceback (most recent call last):
  File "/Users/filippos/.virtualenvs/advocate-defence-payments-deploy/lib/python2.7/site-packages/fabric/main.py", line 745, in main
    *args, **kwargs
  File "/Users/filippos/.virtualenvs/advocate-defence-payments-deploy/lib/python2.7/site-packages/fabric/tasks.py", line 427, in execute
    results['<local-only>'] = task.run(*args, **new_kwargs)
  File "/Users/filippos/.virtualenvs/advocate-defence-payments-deploy/lib/python2.7/site-packages/fabric/tasks.py", line 174, in run
    return self.wrapped(*args, **kwargs)
  File "/Users/filippos/.virtualenvs/advocate-defence-payments-deploy/lib/python2.7/site-packages/bootstrap_cfn/fab_tasks.py", line 260, in exit_maintenance
    for x in elb_conn.cfn.get_stack_load_balancers(stack_name)])
AttributeError: 'dict' object has no attribute 'logical_resource_id'
```

Reason is because the attribute now is now called LogicalResourceId
and PhysicalResourceId.
