### PR TITLE
Default RDS encryption to true

### DIFF
--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -470,7 +470,7 @@ class ConfigParser(object):
             AutoMinorVersionUpgrade=False,
             VPCSecurityGroups=[GetAtt(database_sg, "GroupId")],
             DBSubnetGroupName=Ref(rds_subnet_group),
-            StorageEncrypted=False,
+            StorageEncrypted=True,
             DependsOn=database_sg.title
         )
         resources.append(rds_instance)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -281,7 +281,7 @@ class TestConfigParser(unittest.TestCase):
         db_instance.MasterUserPassword = 'testpassword'
         db_instance.DBName = 'test'
         db_instance.PubliclyAccessible = False
-        db_instance.StorageEncrypted = False
+        db_instance.StorageEncrypted = True
         db_instance.StorageType = 'gp2'
         db_instance.AllocatedStorage = 5
         db_instance.AllowMajorVersionUpgrade = False


### PR DESCRIPTION
At the moment RDS encryption follows AWS defaults, ie, its set to
False. To avoid situations where data is left left secure by
mistake, we default to having encryption on, meaning that if
data security requirements are not explicitly set, we default
to the most secure.
