### PR TITLE
Add random number generator for RDS credentials

### DIFF
--- a/bootstrap_cfn/utils.py
+++ b/bootstrap_cfn/utils.py
@@ -1,4 +1,6 @@
 import os
+import random
+import string
 import sys
 import time
 
@@ -151,3 +153,25 @@ def sleep_countdown(sleep_time):
         sys.stdout.flush()
         time.sleep(1)
         sleep_time -= 1
+
+
+def get_random_string(length=64, alphanumeric=False):
+    """
+    Return a basic pseudo-random string
+
+    Args:
+        length(int): The length of the string to return
+        alphanumeric(bool): True to use only alphanumeric chars,
+            False to use all chars
+
+    Returns:
+        random_string(string): The random string of required length
+    """
+    # Just alphanumeric characters
+    if alphanumeric:
+        chars = string.letters + string.digits
+    else:
+        # Alphanumeric + special characters
+        chars = string.letters + string.digits + string.punctuation
+    random_string = ''.join([random.choice(chars) for x in range(length)])
+    return random_string

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'mock>=1.0.1',
         'testfixtures>=4.1.2',
         'nose',
+        'entropy',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,33 @@
+import random
+
+import unittest
+
+import entropy
+
+from bootstrap_cfn import utils
+
+
+class TestUtils(unittest.TestCase):
+
+    def test_get_random_string_alphanumeric(self):
+        """
+        TestUtils::test_get_random_string: Test getting a random string
+        """
+        no_of_tests = 1000
+        min_key_length = 24
+        max_key_length = 128
+        # Generate some keys and test how random they are
+        for i in range(no_of_tests):
+            length = random.randint(min_key_length, max_key_length)
+            alphanumeric = random.choice([True, False])
+            if alphanumeric:
+                entropy_floor = 0.4
+            else:
+                entropy_floor = 0.5
+            random_string = utils.get_random_string(length, alphanumeric=alphanumeric)
+            string_entropy = entropy.shannon_entropy(random_string)
+            message = ("TestUtils::test_get_random_string: Test: %s: Generated string length:%s alphanumeric:%s entropy:%s string:%s"
+                       % (i, length, alphanumeric, string_entropy, random_string))
+            print(message)
+            self.assertEqual(len(random_string), length)
+            self.assertGreater(string_entropy, entropy_floor, message)


### PR DESCRIPTION
This change removes the requirement for RDS credentials and instead
allows them to be generated using a simple random string generator.
Combined with setting resource defaults, it means that RDS instances
can be sensibly generated from only an empty key,
rds: {}
