### PR TITLE
(WIP) Add option to specify additional ELB aliases

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -318,6 +318,22 @@ It is possilbe to define a custom health check for an ELB like follows::
       Timeout: 5
       UnhealthyThreshold: 2
 
+Additional Aliases
+~~~~~~~~~~~~~~~~~~
+
+You can also have additional entries in the cloudformation config specifying ELB aliases.
+For example,
+
+.. code:: yaml
+
+   elb:
+   - name: myelb
+     aliases:
+       - thiselb
+       - yourelb
+
+The above setup would create route53 A records as aliases to the elb name address. If the aliases already exist, they will not be overwritten by default, although there is the option to forcibly do so.
+
 ELB Certificates
 ~~~~~~~~~~~~~~~~
 

--- a/bootstrap_cfn/r53.py
+++ b/bootstrap_cfn/r53.py
@@ -39,7 +39,7 @@ class R53(object):
             zone = zone['GetHostedZoneResponse']['HostedZone']['Id']
             return zone.replace('/hostedzone/', '')
 
-    def update_dns_record(self, zone, record, record_type, record_value, is_alias=False, dry_run=False):
+    def update_dns_record(self, zone, record, record_type, record_value, action="UPSERT", is_alias=False, dry_run=False):
         '''
         Updates a dns record in route53
 
@@ -48,14 +48,14 @@ class R53(object):
         record_value -- a string if it is not an alias
                         a list, if it is an alias, of parameters to pass to
                         boto record.set_alias() function
+        action -- The action to perform on the record set, default is UPSERT
         is_alias -- a boolean to show if record_value is an alias
         record_type -- a string to specify the record, eg "A"
-
 
         Returns True if update successful or raises an exception if not
         '''
         changes = boto.route53.record.ResourceRecordSets(self.conn_r53, zone)
-        change = changes.add_change("UPSERT", record, record_type, ttl=60)
+        change = changes.add_change(action, record, record_type, ttl=60)
         if is_alias:
             # provide list of params as needed by function set_alias
             # http://boto.readthedocs.org/en/latest/ref/route53.html#boto.route53.record.Record.set_alias
@@ -77,5 +77,7 @@ class R53(object):
             if rr.type == record_type and rr.name == fqdn:
                 if rr.type == 'TXT':
                     rr.resource_records[0] = rr.resource_records[0][1:-1]
+                if len(rr.alias_dns_name) > 0:
+                    return rr.alias_dns_name
                 return rr.resource_records[0]
         return None


### PR DESCRIPTION
This change adds the option of having additional entries in the
cloudformation config specifying ELB aliases. For example

elb:
- name: myelb
  aliases:
  - thiselb
  - yourelb

The above setup would create route53 A records as aliases to the
elb name address. If the aliases already exist, they will not
be overwritten by default, although there is the option to forcibly
do so.
