### PR TITLE
Add DependsOn Requirements to cloudformation

### DIFF
--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -535,7 +535,7 @@ class ConfigParser(object):
             AutoMinorVersionUpgrade=False,
             VPCSecurityGroups=[GetAtt(database_sg, "GroupId")],
             DBSubnetGroupName=Ref(rds_subnet_group),
-            DependsOn=database_sg.title
+            DependsOn=["AttachGateway", database_sg.title],
         )
         resources.append(rds_instance)
 
@@ -738,7 +738,8 @@ class ConfigParser(object):
                     Enabled=True,
                     Timeout=120,
                 ),
-                Policies=elb_policies
+                Policies=elb_policies,
+                DependsOn=["AttachGateway"],
             )
             if "health_check" in elb:
                 load_balancer.HealthCheck = HealthCheck(**elb['health_check'])
@@ -1112,6 +1113,7 @@ class ConfigParser(object):
             LaunchConfigurationName=Ref(launch_config),
             HealthCheckGracePeriod=health_check_grace_period,
             HealthCheckType=health_check_type,
+            DependsOn=["AttachGateway"],
         )
         resources.append(scaling_group)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -312,7 +312,7 @@ class TestConfigParser(unittest.TestCase):
         db_subnet.SubnetIds = [Ref('SubnetA'), Ref('SubnetB'), Ref('SubnetC')]
         db_subnet.DBSubnetGroupDescription = 'VPC Subnets'
 
-        db_instance = rds.DBInstance('RDSInstance', DependsOn=db_sg.title)
+        db_instance = rds.DBInstance('RDSInstance', DependsOn=["AttachGateway", db_sg.title])
         db_instance.MultiAZ = False
         db_instance.MasterUsername = 'testuser'
         db_instance.MasterUserPassword = 'testpassword'
@@ -457,7 +457,8 @@ class TestConfigParser(unittest.TestCase):
                     PolicyType='SSLNegotiationPolicyType',
                     PolicyName='PinDownSSLNegotiationPolicy201505'
                 )
-            ]
+            ],
+            DependsOn=["AttachGateway"],
         )
 
         pt1 = PolicyType(
@@ -566,6 +567,7 @@ class TestConfigParser(unittest.TestCase):
                     PolicyName='PinDownSSLNegotiationPolicy201505'
                 )
             ],
+            DependsOn=["AttachGateway"],
         )
         known_load_balancer_resources = [lb, lb2]
         known_policy_type_resources = [pt1, pt2]
@@ -986,6 +988,7 @@ class TestConfigParser(unittest.TestCase):
                     PolicyName='PinDownSSLNegotiationPolicy201505'
                 )
             ],
+            DependsOn=["AttachGateway"],
         )
 
         Policydockerregistryservice = PolicyType(
@@ -1110,6 +1113,7 @@ class TestConfigParser(unittest.TestCase):
                     PolicyName='PinDownSSLNegotiationPolicy201505'
                 )
             ],
+            DependsOn=["AttachGateway"],
         )
 
         Policydockerregistryservice = PolicyType(
@@ -1213,6 +1217,7 @@ class TestConfigParser(unittest.TestCase):
                     PolicyName='PinDownSSLNegotiationPolicy201505'
                 )
             ],
+            DependsOn=["AttachGateway"],
         )
 
         DNSdevdockerregistryservice = RecordSetGroup(
@@ -1321,7 +1326,8 @@ class TestConfigParser(unittest.TestCase):
             LaunchConfigurationName=Ref("BaseHostLaunchConfig"),
             AvailabilityZones=GetAZs(""),
             HealthCheckGracePeriod=300,
-            HealthCheckType='EC2'
+            HealthCheckType='EC2',
+            DependsOn=["AttachGateway"],
         )
 
         BaseHostSG = SecurityGroup(


### PR DESCRIPTION
Add DependsOn Requirements to cloudformation

Some cloudformation resources depend on other resources before they
can be created or deleted. This especially causes problems when deleting
VPC's, meaning that the delete fails since there are dependent resources
still in the process of being removed form the VPC.

By adding the DependsOn attribute to these resources, this problem can be resolved.
This change uses the AWS guidance on when this is required to add this attribute to resources
that do, or may require it. The details are in the link below.
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html#gatewayattachment

Following the advice in the document above, the resources below are considered,

Already has DependsOn the VPCGatewayAttachment
- Amazon VPC routes that include the Internet gateway

Added DependsOn the VPCGatewayAttachment since EC2 instances have public ips
- Auto Scaling groups
- Elastic Load Balancers

Added DependsOn the VPCGatewayAttachment since they can have public ips
- RDS instances

No action required
- Elastic IP addresses - we dont have any yet
- Amazon EC2 instances - these are handled by the ASG

(Closes #177)
