### PR TITLE
Readd elb permissions to ec2 host for aws-formula

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## UNRELEASED
+
+* Adds missing permission of ELB `Describe*` on Resource `*` to
+  ec2 iam policies.
+
 ## v0.10.0
 
 * Default RDS encryption to true

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -321,8 +321,10 @@ class ConfigParser(object):
             },
         )
         # Set required policy actions
+        # elasticloadbalancing:Describe* "*" needed for aws-formula and cron-formula
         policy_actions = [{"Action": ["autoscaling:Describe*"], "Resource": "*", "Effect": "Allow"},
-                          {"Action": ["cloudformation:Describe*"], "Resource": "*", "Effect": "Allow"}]
+                          {"Action": ["cloudformation:Describe*"], "Resource": "*", "Effect": "Allow"},
+                          {"Action": ["elasticloadbalancing:Describe*"], "Resource": "*", "Effect": "Allow"}]
 
         # Only define policy actions if the components are enabled in the config
         if 'ec2' in self.data:
@@ -331,7 +333,6 @@ class ConfigParser(object):
         if 'rds' in self.data:
             policy_actions.append({"Action": ["rds:Describe*"], "Resource": "*", "Effect": "Allow"})
         if 'elasticache' in self.data:
-            policy_actions.append({"Action": ["elasticloadbalancing:Describe*"], "Resource": "*", "Effect": "Allow"})
             policy_actions.append({"Action": ["elasticache:Describe*"], "Resource": "*", "Effect": "Allow"})
         if 's3' in self.data:
             policy_actions.append({"Action": ["s3:List*"], "Resource": "*", "Effect": "Allow"})

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -84,7 +84,11 @@ class TestConfigParser(unittest.TestCase):
                  'Effect': 'Allow'},
                 {'Action': ['cloudformation:Describe*'],
                  'Resource': '*',
-                 'Effect': 'Allow'}]
+                 'Effect': 'Allow'},
+                {'Action': ['elasticloadbalancing:Describe*'],
+                 'Effect': 'Allow',
+                 'Resource': '*'}
+                ]
         }
         role_policy.Roles = [basehost_role_ref]
 
@@ -122,6 +126,9 @@ class TestConfigParser(unittest.TestCase):
                 {'Action': ['cloudformation:Describe*'],
                  'Resource': '*',
                  'Effect': 'Allow'},
+                {'Action': ['elasticloadbalancing:Describe*'],
+                 'Resource': '*',
+                 'Effect': 'Allow'},
                 {'Action': ['ec2:Describe*'],
                  'Resource': '*',
                  'Effect': 'Allow'},
@@ -129,9 +136,6 @@ class TestConfigParser(unittest.TestCase):
                  'Resource': '*',
                  'Effect': 'Allow'},
                 {'Action': ['rds:Describe*'],
-                 'Resource': '*',
-                 'Effect': 'Allow'},
-                {'Action': ['elasticloadbalancing:Describe*'],
                  'Resource': '*',
                  'Effect': 'Allow'},
                 {'Action': ['elasticache:Describe*'],


### PR DESCRIPTION
Highstating with aws-formula currently produces this error:

```
[ERROR   ] 403 Forbidden
[ERROR   ] <ErrorResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
  <Error>
    <Type>Sender</Type>
    <Code>AccessDenied</Code>
    <Message>User: arn:aws:sts::NNNNNNNNNNN:assumed-role/.. is not authorized to perform: elasticloadbalancing:DescribeLoadBalancers</Message>
  </Error>
  <RequestId>ffa4bb0f-420e-11e6-a63b-e3fe5e66e8f5</RequestId>
</ErrorResponse>

[ERROR   ] Error getting ELB names: BotoServerError: 403 Forbidden
<ErrorResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
  <Error>
    <Type>Sender</Type>
    <Code>AccessDenied</Code>
    <Message>User: arn:aws:sts::NNNNNNNNNNN:assumed-role/.. is not authorized to perform: elasticloadbalancing:DescribeLoadBalancers</Message>
  </Error>
  <RequestId>ffa4bb0f-420e-11e6-a63b-e3fe5e66e8f5</RequestId>
</ErrorResponse>
Traceback (most recent call last):
  File "a", line 43, in get_elb_lbs
    all_lbs = [lb for lb in elb_connection.get_all_load_balancers()
  File "/usr/local/lib/python2.7/dist-packages/boto/ec2/elb/__init__.py", line 135, in get_all_load_balancers
    [('member', LoadBalancer)])
  File "/usr/local/lib/python2.7/dist-packages/boto/connection.py", line 1186, in get_list
    raise self.ResponseError(response.status, response.reason, body)
BotoServerError: BotoServerError: 403 Forbidden
<ErrorResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
  <Error>
    <Type>Sender</Type>
    <Code>AccessDenied</Code>
    <Message>User: arn:aws:sts::NNNNNNNNNNN:assumed-role/.. is not authorized to perform: elasticloadbalancing:DescribeLoadBalancers</Message>
  </Error>
  <RequestId>ffa4bb0f-420e-11e6-a63b-e3fe5e66e8f5</RequestId>
</ErrorResponse>

{'custom_grain_error': True}
```

This is due to:
https://github.com/ministryofjustice/bootstrap-cfn/commit/06a185a04432e5fc95f159535303343affadaa2b

Adding access to just its own load balancer is not enough, because to query
(eg: Describe) it you have to already know and supply the resource name.
If no name is specified then a `*` is implied.
