### PR TITLE
Update flake8-import-order to 2a595f1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@
 language: python
 
 install:
-  - pip install coveralls flake8 git+git://github.com/public/flake8-import-order@2ac7052#egg=flake8-import-order
-
+  - pip install coveralls flake8 git+git://github.com/public/flake8-import-order@2a595f1#egg=flake8-import-order
 python:
   - "2.7"
 


### PR DESCRIPTION
Test starts failing with the error below, which is fixed in 2a595f1
(aka version 0.9 unreleased):

```
Traceback (most recent call last):
  File "/Users/yufang/.virtualenvs/test/bin/flake8", line 11, in <module>
    sys.exit(main())
  File "/Users/yufang/.virtualenvs/test/lib/python2.7/site-packages/flake8/main/cli.py", line 16, in main
    app.run(argv)
  File "/Users/yufang/.virtualenvs/test/lib/python2.7/site-packages/flake8/main/application.py", line 316, in run
    self._run(argv)
  File "/Users/yufang/.virtualenvs/test/lib/python2.7/site-packages/flake8/main/application.py", line 299, in _run
    self.initialize(argv)
  File "/Users/yufang/.virtualenvs/test/lib/python2.7/site-packages/flake8/main/application.py", line 290, in initialize
    self.register_plugin_options()
  File "/Users/yufang/.virtualenvs/test/lib/python2.7/site-packages/flake8/main/application.py", line 150, in register_plugin_options
    self.check_plugins.register_options(self.option_manager)
  File "/Users/yufang/.virtualenvs/test/lib/python2.7/site-packages/flake8/plugins/manager.py", line 451, in register_options
    list(self.manager.map(register_and_enable))
  File "/Users/yufang/.virtualenvs/test/lib/python2.7/site-packages/flake8/plugins/manager.py", line 261, in map
    yield func(self.plugins[name], *args, **kwargs)
  File "/Users/yufang/.virtualenvs/test/lib/python2.7/site-packages/flake8/plugins/manager.py", line 447, in register_and_enable
    call_register_options(plugin)
  File "/Users/yufang/.virtualenvs/test/lib/python2.7/site-packages/flake8/plugins/manager.py", line 357, in generated_function
    return method(optmanager, *args, **kwargs)
  File "/Users/yufang/.virtualenvs/test/lib/python2.7/site-packages/flake8/plugins/manager.py", line 207, in register_options
    add_options(optmanager)
  File "/Users/yufang/.virtualenvs/test/lib/python2.7/site-packages/flake8_import_order/flake8_linter.py", line 32, in add_options
    parser.config_options.append("application-import-names")
AttributeError: 'OptionManager' object has no attribute 'config_options'
```
