### PR TITLE
Rename S3 bucket output to be consistent

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -432,11 +432,11 @@ These entries can also specify their own policies or use the default, vpc limite
 
    s3:
       buckets:
-         - name: mybucket
+         - name: mybucketid
            policy: some_policy
-         - name: myotherbucket
+         - name: myotherbucketid
 
-The outputs of these buckets will be the bucket name postfixed by 'Name', ie, mybucketName
+The outputs of these buckets will be the bucket name postfixed by 'BucketName', ie, mybucketidBucketName
 
 Includes
 ++++++++

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -464,7 +464,7 @@ class ConfigParser(object):
         # Add the bucket name to the list of cloudformation
         # outputs
         template.add_output(Output(
-            "{}Policy".format(bucket_name),
+            "{}BucketName".format(bucket_name),
             Description="S3 bucket name",
             Value=Ref(bucket)
         ))


### PR DESCRIPTION
When we create cloudformation things we can create Outputs that represent them,
which then get turned into grains, meaning that we can do lookups on randomly
named resources. The buckets that are created have 2 things, a name, and a policy.
The output for the S3 bucket currently is named like it references the policy,
but actually it references the name. This change makes it more coherent with the
form '<bucket_id>BucketName'.
