### PR TITLE
Add KeyName to fab parameters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,15 +54,16 @@ If your ``$CWD`` is anywhere else, you need to pass in a path to particular fabr
 - **environment:dev** - The key name to read in the file specified to the ``config`` task
 - **config:/path/to/file.yaml** - The location to the project YAML file
 - **tag:test** - stack tag to differentiate between stacks
+- **keyname:keyname** - the name of the keypair you uploaded in AWS which should store your SSH public key.
 
 Multiple Stacks
 ===============
 
 If you want to bring up a new stack as active stack, you will need to run the following fab tasks which we will explain later:
-- **`fab-env cfn_create`:** create a new stack with a tag
+- **`fab-env keyname:keyops tag:test cfn_create`:** create a new stack with a tag and keyname specified.
 - **`fab-env salt.wait_for_minions`:** check if creation is done
-- **`fab-env -u ubuntu update`:** install salt on the stack, add admins in keys.sls
-- **`fab-env -u [your-ssh-name] update`:** remove `ubuntu`
+- **`fab-env -i ~/.ssh/id_your_ssh_private_key -u ubuntu update`:** install salt on the stack, add admins from keys.sls
+- **`fab-env -u [your-ssh-name] update`:** remove `ubuntu` user for security reason
 
 Here `fab-env` refers to `fab application:courtfinder aws:prod environment:dev config:/path/to/courtfinder-dev.yaml passwords:/path/to/courfinder-dev-secrets.yaml`.
 

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -74,6 +74,7 @@ class ProjectConfig:
                 # Overwrite user config with password config values
                 self.config[config_key] = utils.dict_merge(self.config[config_key],
                                                            passwords_config.get(config_key, {}))
+
         except KeyError:
             raise errors.BootstrapCfnError("Environment " + environment + " not found")
 
@@ -109,13 +110,14 @@ class ConfigParser(object):
 
     config = {}
 
-    def __init__(self, data, stack_name, environment=None, application=None):
+    def __init__(self, data, stack_name, environment=None, application=None, keyname=None):
         self.stack_name = stack_name
         self.data = data
         self.stack_id = self.stack_name.split('-')[-1]
         # Some things possibly used in user data templates
         self.environment = environment
         self.application = application
+        self.keyname = keyname
 
     def process(self):
         template = self.base_template()
@@ -1085,7 +1087,7 @@ class ConfigParser(object):
 
         launch_config = LaunchConfiguration(
             "BaseHostLaunchConfig",
-            KeyName=data['parameters']['KeyName'],
+            KeyName=self.get_keyname(),
             SecurityGroups=[Ref(g) for g in sgs],
             InstanceType=data['parameters']['InstanceType'],
             AssociatePublicIpAddress=True,
@@ -1159,6 +1161,9 @@ class ConfigParser(object):
     @classmethod
     def _get_elb_canonical_name(cls, elb_yaml_name):
         return 'ELB-{}'.format(elb_yaml_name.replace('.', ''))
+
+    def get_keyname(self):
+        return self.keyname
 
     def _attach_elbs(self, template):
         if 'elb' not in self.data:

--- a/bootstrap_cfn/config_defaults.yaml
+++ b/bootstrap_cfn/config_defaults.yaml
@@ -6,7 +6,6 @@ prod:
       max: 5
       min: 1
     parameters: &prod_ec2_parameters
-      KeyName: default
       InstanceType: t2.micro
     block_devices: &prod_ec2_block_devices
       - DeviceName: /dev/sda1
@@ -34,7 +33,6 @@ dev:
       max: 3
       min: 1
     parameters: &dev_ec2_parameters
-      KeyName: default
       InstanceType: t2.micro
     block_devices: &dev_ec2_block_devices
       - DeviceName: /dev/sda1

--- a/tests/test_fab_tasks.py
+++ b/tests/test_fab_tasks.py
@@ -304,6 +304,7 @@ class TestFabTasks(unittest.TestCase):
         print "{}.{} logs".format(stack, stack_name)
         return True
 
+    @patch('bootstrap_cfn.fab_tasks._validate_fabric_env')
     @patch('bootstrap_cfn.utils.get_events', return_value=[])
     @patch('bootstrap_cfn.config.ConfigParser.process', return_value="test")
     @patch('bootstrap_cfn.fab_tasks.get_cloudformation_tags', return_value="test")
@@ -323,7 +324,8 @@ class TestFabTasks(unittest.TestCase):
                                     get_connection_function,
                                     get_cloudformation_tags_function,
                                     process_function,
-                                    get_events_function):
+                                    get_events_function,
+                                    _validate_fabric_env_function):
         '''
         create a stack without uploading ssl
         Note: when testing creating stack, get_stack_name.return_value
@@ -344,10 +346,14 @@ class TestFabTasks(unittest.TestCase):
         Returns:
 
         '''
+        # this does not mock fabric env value actually.
+        # I just mock the whole function to do nothing for test simplicity.
+        _validate_fabric_env_function.side_effect = {"env.keyname.return_value": "default"}
+
         get_connection_function.side_effect = self.connection_side_effect
         basic_config_mock = yaml.load(set_up_basic_config())
         get_config_function.return_value = config.ConfigParser(
-            basic_config_mock, "unittest_stack_name", "dev", "test")
+            basic_config_mock, "unittest_stack_name", "dev", "test", "default")
         ret = fab_tasks.cfn_create(False)
         self.assertTrue(ret)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -809,7 +809,8 @@ class TestConfigParser(unittest.TestCase):
         compare(elb_dict['ELBtestdevexternal']['Properties']['SecurityGroups'],
                 [{u'Ref': u'SGName'}])
 
-    def test_cf_includes(self):
+    @patch('bootstrap_cfn.config.ConfigParser.get_keyname', return_value='default')
+    def test_cf_includes(self, get_keyname_mock):
         project_config = ProjectConfig('tests/sample-project.yaml',
                                        'dev',
                                        'tests/sample-project-passwords.yaml')
@@ -853,7 +854,8 @@ class TestConfigParser(unittest.TestCase):
         outputs = cfg['Outputs']
         compare(known_outputs, outputs)
 
-    def test_process(self):
+    @patch('bootstrap_cfn.config.ConfigParser.get_keyname', return_value='default')
+    def test_process(self, get_keyname_mock):
         """
         This isn't the best test, but we at least check that we have the right
         Resource names returned
@@ -910,7 +912,8 @@ class TestConfigParser(unittest.TestCase):
         }
         compare(mappings, expected)
 
-    def test_process_with_vpc_config(self):
+    @patch('bootstrap_cfn.config.ConfigParser.get_keyname', return_value='default')
+    def test_process_with_vpc_config(self, get_keyname_mock):
         """
         This isn't the best test, but we at least check that we have the right
         Resource names returned
@@ -973,7 +976,8 @@ class TestConfigParser(unittest.TestCase):
         }
         compare(mappings, expected)
 
-    def test_process_no_elbs_no_rds(self):
+    @patch('bootstrap_cfn.config.ConfigParser.get_keyname', return_value='default')
+    def test_process_no_elbs_no_rds(self, get_keyname_mock):
         project_config = ProjectConfig('tests/sample-project.yaml', 'dev')
         # Assuming there's no ELB defined
         project_config.config.pop('elb')
@@ -981,7 +985,8 @@ class TestConfigParser(unittest.TestCase):
         config = ConfigParser(project_config.config, 'my-stack-name')
         config.process()
 
-    def test_ami_overrides_os_default(self):
+    @patch('bootstrap_cfn.config.ConfigParser.get_keyname', return_value='default')
+    def test_ami_overrides_os_default(self, get_keyname_mock):
         self.maxDiff = None
         project_config = ProjectConfig(
                 'tests/sample-project.yaml',
@@ -1402,7 +1407,8 @@ class TestConfigParser(unittest.TestCase):
         compare(self._resources_to_dict(known),
                 self._resources_to_dict(elb_cfg))
 
-    def test_ec2(self):
+    @patch('bootstrap_cfn.config.ConfigParser.get_keyname', return_value='default')
+    def test_ec2(self, get_keyname_mock):
 
         self.maxDiff = None
 
@@ -1495,12 +1501,12 @@ class TestConfigParser(unittest.TestCase):
 
         compare(self._resources_to_dict(known), ec2_json)
 
+    @patch('bootstrap_cfn.config.ConfigParser.get_keyname', return_value='default')
     # We just want to test that when we have userdata we return the right LaunchConfig.
-    def test_launchconfig_userdata(self):
+    def test_launchconfig_userdata(self, get_keyname_mock):
         config = ConfigParser(
             ProjectConfig('tests/sample-project.yaml', 'dev').config,
             'my-stack-name')
-
         BaseHostLaunchConfig = LaunchConfiguration(
             "BaseHostLaunchConfig",
             ImageId=FindInMap("AWSRegion2AMI", Ref("AWS::Region"), "AMI"),
@@ -1625,7 +1631,8 @@ class TestConfigParser(unittest.TestCase):
             config.get_hostname_boothook(cfg)
             self.fail()
 
-    def test_ec2_with_no_block_device_specified(self):
+    @patch('bootstrap_cfn.config.ConfigParser.get_keyname', return_value='default')
+    def test_ec2_with_no_block_device_specified(self, get_keyname_mock):
         project_config = ProjectConfig('tests/sample-project.yaml', 'dev')
         project_config.config['ec2'].pop('block_devices')
         config = ConfigParser(project_config.config, 'my-stack-name')


### PR DESCRIPTION
This commit adds keyname as a fab parameter.
with it, you can set it to your keypair in AWS
KeyName defined in config file will not be used.
