### PR TITLE
Update default RDS version to 9.5.4

### DIFF
--- a/bootstrap_cfn/config_defaults.yaml
+++ b/bootstrap_cfn/config_defaults.yaml
@@ -1,4 +1,5 @@
 # Production is secure by default and may have high resource specifications
+# flake8: noqa
 prod:
   ec2: &prod_ec2
     auto_scaling: &prod_ec2_auto_scaling

--- a/bootstrap_cfn/config_defaults.yaml
+++ b/bootstrap_cfn/config_defaults.yaml
@@ -15,7 +15,7 @@ prod:
     storage-type: 'gp2'
     backup-retention-period: 30
     db-engine: 'postgres'
-    db-engine-version: '9.3.5'
+    db-engine-version: '9.5.4'
     instance-class: 'db.t2.large'
     multi-az: True
     storage-encrypted: True
@@ -42,7 +42,7 @@ dev:
     storage-type: 'gp2'
     backup-retention-period: 1
     db-engine: 'postgres'
-    db-engine-version: '9.3.5'
+    db-engine-version: '9.5.4'
     instance-class: 'db.t2.small'
     multi-az: False
     storage-encrypted: False

--- a/docs/sample-project.yaml
+++ b/docs/sample-project.yaml
@@ -1,3 +1,4 @@
+# flake8: noqa
 dev:
   vpc:
     CIDR: 10.0.0.0/16

--- a/docs/sample-project.yaml
+++ b/docs/sample-project.yaml
@@ -91,7 +91,7 @@ dev:
     instance-class: db.t2.micro
     multi-az: false
     db-engine: postgres
-    db-engine-version: 9.3.5
+    db-engine-version: 9.5.4
 #  ssl:
 #    my-cert:
 #      cert: |

--- a/tests/sample-project.yaml
+++ b/tests/sample-project.yaml
@@ -72,7 +72,7 @@ dev:
     instance-class: db.t2.micro
     multi-az: false
     db-engine: postgres
-    db-engine-version: 9.3.5
+    db-engine-version: 9.5.4
   elasticache:
     clusters: 3
     node_type: cache.m1.medium

--- a/tests/sample-project.yaml
+++ b/tests/sample-project.yaml
@@ -1,3 +1,4 @@
+# flake8: noqa
 dev:
   vpc:
     CIDR: 10.0.0.0/16

--- a/tests/test.py
+++ b/tests/test.py
@@ -65,7 +65,7 @@ class CfnTestCase(unittest.TestCase):
                                    'scheme': 'internet-facing'}],
                           'rds': {'backup-retention-period': 1,
                                   'db-engine': 'postgres',
-                                  'db-engine-version': '9.3.5',
+                                  'db-engine-version': '9.5.4',
                                   'db-master-password': 'testpassword',
                                   'db-master-username': 'testuser',
                                   'db-name': 'test',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -339,7 +339,7 @@ class TestConfigParser(unittest.TestCase):
         db_instance.BackupRetentionPeriod = 1
         db_instance.DBInstanceClass = 'db.t2.micro'
         db_instance.Engine = 'postgres'
-        db_instance.EngineVersion = '9.3.5'
+        db_instance.EngineVersion = '9.5.4'
         db_instance.VPCSecurityGroups = [GetAtt(db_sg, 'GroupId')]
         db_instance.DBSubnetGroupName = Ref(db_subnet)
 
@@ -429,7 +429,7 @@ class TestConfigParser(unittest.TestCase):
         db_instance.BackupRetentionPeriod = 1
         db_instance.DBInstanceClass = 'db.t2.micro'
         db_instance.Engine = 'postgres'
-        db_instance.EngineVersion = '9.3.5'
+        db_instance.EngineVersion = '9.5.4'
         db_instance.VPCSecurityGroups = [GetAtt(db_sg, 'GroupId')]
         db_instance.DBSubnetGroupName = Ref(db_subnet)
 


### PR DESCRIPTION
The default for RDS in AWS is now 9.5.4, this change matches that.