### PR TITLE
Try to delete SSL certs only if defined in cf template

### DIFF
--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -628,6 +628,8 @@ def cfn_delete(force=False, pre_delete_callbacks=None):
             iam.delete_ssl_certificate(cfn_config.ssl(), stack_name)
         except AttributeError, boto.exception:
             print green("SSL certificate was already deleted.")
+        except KeyError:
+            print green("SSL does not exist in cloudformation configuration file")
 
     return True
 
@@ -681,8 +683,10 @@ def cfn_create(test=False):
             print red("Deleting SSL certificates from stack")
             iam.delete_ssl_certificate(cfn_config.ssl(), stack_name)
         import traceback
+        red("Failed to create: {error}".format(error=traceback.format_exc()))
+        red("Deleting stack and aborting...)")
         cfn_delete(True)
-        abort(red("Failed to create: {error}".format(error=traceback.format_exc())))
+        abort(red("Aborted..."))
 
     print green("\nSTACK {0} CREATING...\n").format(stack_name)
     if not env.blocking:


### PR DESCRIPTION
**Try to delete SSL certs only if defined in cf template**

The obvious culprit is that we can call cfn_delete after we've changed
the template file though and that makes things a bit more
complicated. Alternatively, we could ignore that and just continue if
exception occurs