### PR TITLE
Disable production settings on staging

### DIFF
--- a/bootstrap_cfn/config_defaults.yaml
+++ b/bootstrap_cfn/config_defaults.yaml
@@ -53,20 +53,18 @@ dev:
     port: 6379
     engine: 'redis'
 
-# Staging should be equivalent to prod
 staging:
   ec2:
-    <<: *prod_ec2
+    <<: *dev_ec2
   rds:
-    <<: *prod_rds
+    <<: *dev_rds
   elasticache:
-    <<: *prod_elasticache
+    <<: *dev_elasticache
 
-# The default should be the most secure
 default:
   ec2:
-    <<: *prod_ec2
+    <<: *dev_ec2
   rds:
-    <<: *prod_rds
+    <<: *dev_rds
   elasticache:
-    <<: *prod_elasticache
+    <<: *dev_elasticache


### PR DESCRIPTION
We are now not requiring prod performance instances on staging,
so this change will reduce the defaults.