### PR TITLE
Fix cfn delete on wsproxy

### DIFF
--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -610,9 +610,12 @@ def cfn_delete(force=False, pre_delete_callbacks=None):
     zone_id = get_zone_id()
     zone_name = get_zone_name()
 
-    txt_tag_record = get_tag_record_name(stack_tag)
-    print green("\nDELETING TXT RECORDS {}-{}...\n".format(txt_tag_record, zone_name))
-    r53_conn.delete_txt_record(zone_name, zone_id, txt_tag_record)
+    try:
+        txt_tag_record = get_tag_record_name(stack_tag)
+        print green("\nDELETING TXT RECORDS {}-{}...\n".format(txt_tag_record, zone_name))
+        r53_conn.delete_txt_record(zone_name, zone_id, txt_tag_record)
+    except boto.route53.exception.DNSServerError:
+            pass
 
     for elb in get_all_elbs():
         logger.info("Deleting '{}-{}' from '{}' ({})...".format(elb, stack_id, zone_name, zone_id))

--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -603,12 +603,14 @@ def cfn_delete(force=False, pre_delete_callbacks=None):
     zone_name = get_zone_name()
 
     txt_tag_record = get_tag_record_name(stack_tag)
+    print green("\nDELETING TXT RECORDS {}-{}...\n".format(txt_tag_record, zone_name))
+    r53_conn.delete_txt_record(zone_name, zone_id, txt_tag_record)
 
-    print green("\nDELETING DNS RECORDS...\n")
     for elb in get_all_elbs():
         logger.info("Deleting '{}-{}' from '{}' ({})...".format(elb, stack_id, zone_name, zone_id))
         try:
-            r53_conn.delete_record(zone_name, zone_id, elb, stack_id, stack_tag, txt_tag_record)
+            print green("\nDELETING Alias RECORDS {}-{}-{}...\n".format(elb, stack_id, zone_name))
+            r53_conn.delete_alias_record(zone_name, zone_id, elb, stack_id, stack_tag)
         except boto.route53.exception.DNSServerError:
             pass
 

--- a/bootstrap_cfn/r53.py
+++ b/bootstrap_cfn/r53.py
@@ -141,7 +141,6 @@ class R53(object):
                 active_alias_record_name = "{}.{}".format(active_elb_name, zone_name)
                 self.delete_dns_record(zone_id, active_alias_record_name, 'A', active_alias_record_value, is_alias=True)
 
-
     def get_record(self, zone_name, zone_id, record_name, record_type):
         """
 

--- a/bootstrap_cfn/r53.py
+++ b/bootstrap_cfn/r53.py
@@ -98,7 +98,17 @@ class R53(object):
             changes.commit()
         return True
 
-    def delete_record(self, zone_name, zone_id, elb_name, stack_id, stack_tag, txt_tag_record):
+    def delete_txt_record(self, zone_name, zone_id, txt_tag_record):
+
+        # delete TXT record
+        txt_record_name = "{}.{}".format(txt_tag_record, zone_name)
+        txt_record_value = '"{}"'.format(self.get_record(
+                zone_name, zone_id, txt_tag_record, 'TXT'))
+        if txt_record_value:
+            self.delete_dns_record(zone_id, txt_record_name, 'TXT', txt_record_value)
+        return True
+
+    def delete_alias_record(self, zone_name, zone_id, elb_name, stack_id, stack_tag):
         '''
         Delete "active" or tagged Alias and TXT records if they exist
         Args:
@@ -131,13 +141,6 @@ class R53(object):
                 active_alias_record_name = "{}.{}".format(active_elb_name, zone_name)
                 self.delete_dns_record(zone_id, active_alias_record_name, 'A', active_alias_record_value, is_alias=True)
 
-        # delete TXT record
-        txt_record_name = "{}.{}".format(txt_tag_record, zone_name)
-        txt_record_value = '"{}"'.format(self.get_record(
-                zone_name, zone_id, txt_tag_record, 'TXT'))
-        if txt_record_value:
-            self.delete_dns_record(zone_id, txt_record_name, 'TXT', txt_record_value)
-        return True
 
     def get_record(self, zone_name, zone_id, record_name, record_type):
         """


### PR DESCRIPTION
cfn_delete won't delete txt records when elb{} in yanl configuration is empty. this PR is to separate deleting txt records and alias.