### PR TITLE
Fix ACM certificate functionality.

### DIFF
--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -1143,20 +1143,30 @@ class ConfigParser(object):
         for key, value in acm_data.get('tags', {}).iteritems():
             tag_pair = {'Key': key, 'Value': value}
             tags.append(tag_pair)
+
         # Parse the certificate key to get a cloudformation compatible canonical name
         canonical_certificate_name = self._get_alphanumeric_name(certificate_name)
+
+
+        #
+        # One domain validation option for main domain and add one entry for
+        # each domain in SAN
+        #
+        validation_domain = acm_data.get('validation_domain', domain_name)
+        dnv = [DomainValidationOption(
+                    DomainName=domain_name,
+                    ValidationDomain=validation_domain)]
+        dnv += [DomainValidationOption(
+            DomainName=d,
+            ValidationDomain=validation_domain)
+         for d in acm_data.get('subject_alternative_names', [])]
+
         certificate = Certificate(
             canonical_certificate_name,
             DomainName=domain_name,
             SubjectAlternativeNames=acm_data.get('subject_alternative_names', []),
-            DomainValidationOptions=[
-                DomainValidationOption(
-                    DomainName=domain_name,
-                    ValidationDomain=acm_data.get('validation_domain', domain_name),
-                ),
-            ],
-            Tags=tags
-        )
+            DomainValidationOptions=dnv,
+            Tags=tags)
         return certificate
 
     def _get_manual_ssl_certificate(self, certificate_name):


### PR DESCRIPTION
**Fix ACM certificate functionality.**
The SSL certificates defined in the ACM section of the yaml file were
not being reused across ELBs, causing a troposphere exception error.