### PR TITLE
Parse ACM key into alphanumeric

### DIFF
--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -1134,9 +1134,10 @@ class ConfigParser(object):
         for key, value in acm_data.get('tags', {}).iteritems():
             tag_pair = {'Key': key, 'Value': value}
             tags.append(tag_pair)
-
+        # Parse the certificate key to get a cloudformation compatible canonical name
+        canonical_certificate_name = self._get_alphanumeric_name(certificate_name)
         certificate = Certificate(
-            certificate_name,
+            canonical_certificate_name,
             DomainName=domain_name,
             SubjectAlternativeNames=acm_data.get('subject_alternative_names', []),
             DomainValidationOptions=[
@@ -1193,6 +1194,11 @@ class ConfigParser(object):
     @classmethod
     def _get_elb_canonical_name(cls, elb_yaml_name):
         return 'ELB-{}'.format(elb_yaml_name.replace('.', ''))
+
+    @classmethod
+    def _get_alphanumeric_name(cls, name):
+        parsed_name = "".join([c if c.isalnum() else "" for c in name])
+        return parsed_name
 
     def get_keyname(self):
         return self.keyname

--- a/tests/cloudformation/sample-project_acm.yaml
+++ b/tests/cloudformation/sample-project_acm.yaml
@@ -1,0 +1,45 @@
+# noqa
+dev:
+  ec2:
+    tags:
+      Apps: test
+    security_groups:
+      AnotherSG:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          SourceSecurityGroupName:
+            Ref: BaseHostSG
+      BaseHostSG:
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+  elb:
+    - name: helloworld
+      hosted_zone: test.dsd.io.
+      scheme: internet-facing
+      certificate_name: mycert
+      listeners:
+        - LoadBalancerPort: 80
+          InstancePort: 80
+          Protocol: TCP
+        - LoadBalancerPort: 443
+          InstancePort: 443
+          Protocol: TCP
+  acm:
+    mycert:
+      domain: helloworld.test.dsd.io
+      subject_alternative_names:
+          - goodbye.test.dsd.io
+          - hello_again.test.dsd.io
+      validation_domain: dsd.io
+      tags:
+        test_key1: test_value_1
+        test_key2: test_value_2
+    mycert-dev.something.io:
+      domain: helloworld.test.dsd.io

--- a/tests/test_acm.py
+++ b/tests/test_acm.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+import json
+import unittest
+
+from testfixtures import compare
+
+from troposphere.certificatemanager import Certificate, DomainValidationOption
+
+from bootstrap_cfn.config import ConfigParser, ProjectConfig
+
+
+class TestConfig(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+
+class TestConfigParser(unittest.TestCase):
+
+    def _resources_to_dict(self, resources):
+        resources_dict = {}
+        for resource in resources:
+            resources_dict[resource.title] = resource.to_dict()
+        return json.loads(json.dumps(resources_dict))
+
+    def test_acm(self):
+        project_config = ProjectConfig('tests/cloudformation/sample-project_acm.yaml', 'dev')
+        config_parser = ConfigParser(project_config.config, 'my-stack-name')
+        certificate_name = 'mycert'
+        domain_name = 'helloworld.test.dsd.io'
+        validation_domain = 'dsd.io'
+        tags = [{
+            'Key': 'Name',
+            'Value': {'Fn::Join': ['', [{'Ref': u'AWS::StackName'}, '-', u'acm']]}},
+            {'Key': 'test_key1', 'Value': 'test_value_1'},
+            {'Key': 'test_key2', 'Value': 'test_value_2'}
+        ]
+        subject_alternative_names = ['goodbye.test.dsd.io', 'hello_again.test.dsd.io']
+
+        domain_validation_options = DomainValidationOption(
+            DomainName=domain_name,
+            ValidationDomain=validation_domain
+        )
+        ACMCertificate = Certificate(
+                certificate_name,
+                DomainName=domain_name,
+                SubjectAlternativeNames=subject_alternative_names,
+                DomainValidationOptions=[domain_validation_options],
+                Tags=tags
+            )
+        certificate_cfg = [config_parser._get_acm_certificate(certificate_name)]
+        expected = [ACMCertificate]
+        compare(self._resources_to_dict(expected),
+                self._resources_to_dict(certificate_cfg))
+
+    def test_acm_non_alphanumeric(self):
+        project_config = ProjectConfig('tests/cloudformation/sample-project_acm.yaml', 'dev')
+        config_parser = ConfigParser(project_config.config, 'my-stack-name')
+        certificate_name = 'mycert-dev.something.io'
+        parsed_certificate_name = 'mycertdevsomethingio'
+        domain_name = 'helloworld.test.dsd.io'
+        tags = [{
+            'Key': 'Name',
+            'Value': {'Fn::Join': ['', [{'Ref': u'AWS::StackName'}, '-', u'acm']]}}
+        ]
+        subject_alternative_names = []
+
+        domain_validation_options = DomainValidationOption(
+            DomainName=domain_name,
+            ValidationDomain=domain_name
+        )
+        ACMCertificate = Certificate(
+                parsed_certificate_name,
+                DomainName=domain_name,
+                SubjectAlternativeNames=subject_alternative_names,
+                DomainValidationOptions=[domain_validation_options],
+                Tags=tags
+            )
+        certificate_cfg = [config_parser._get_acm_certificate(certificate_name)]
+        expected = [ACMCertificate]
+        compare(self._resources_to_dict(expected),
+                self._resources_to_dict(certificate_cfg))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The cloudformation config file ACM key is used to generate a
cloudformation resource name for internal use and so must be an alphanumeric.
This change parses the key to ensure it meets the AWS syntax criteria.