### PR TITLE
cfn_update process for EC2 resources

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,6 +151,23 @@ You can also delete any stack you want no more by specifying the tag, or remove 
 NB ``tag_name`` can be any existing tag. It defaults to `active`.
 When deleting an active stack, only active DNS records will be removed without harming any existing stacks. Otherwise the whole stack along with dns records are being removed.
 
+cfn_update
+----------
+
+Partial support for cloudformation updates is also supported on the EC2 and ELB sections of the configuration file.
+
+.. code:: bash
+
+    fab application:courtfinder aws:my_project_prod environment:dev config:/path/to/courtfinder-dev.yaml tag:[tag_name] cfn_update
+
+NB Running this command will show you some structured output of what
+changes and how. Also a unified diff is printed on output between the
+old and the new Launch Configuration sections. Although we have gone
+to great lengths with this command, it can result in destructive
+operations, particularly if one reduced the desired/max/min capacities
+of the Auto Scaling Group.
+
+
 get_stack_list
 ---------------
 

--- a/bootstrap_cfn/cloudformation.py
+++ b/bootstrap_cfn/cloudformation.py
@@ -40,7 +40,7 @@ class Cloudformation:
     def stack_done(self, stack_id):
         stack_events = self.conn_cfn.describe_stack_events(stack_id)
         if stack_events[0].resource_type == 'AWS::CloudFormation::Stack'\
-                and stack_events[0].resource_status in ['CREATE_COMPLETE', 'CREATE_FAILED', 'ROLLBACK_COMPLETE']:
+                and stack_events[0].resource_status in ['CREATE_COMPLETE', 'CREATE_FAILED', 'ROLLBACK_COMPLETE', 'UPDATE_COMPLETE']:
             return True
         return False
 

--- a/bootstrap_cfn/cloudformation.py
+++ b/bootstrap_cfn/cloudformation.py
@@ -1,4 +1,3 @@
-
 import boto.cloudformation
 
 import boto3
@@ -22,6 +21,12 @@ class Cloudformation:
                                            template_body=template_body,
                                            capabilities=['CAPABILITY_IAM'],
                                            tags=tags)
+        return stack
+
+    def update(self, stack_name, template_body):
+        stack = self.conn_cfn.update_stack(stack_name=stack_name,
+                                           template_body=template_body,
+                                           capabilities=['CAPABILITY_IAM'])
         return stack
 
     def delete(self, stack_name):

--- a/bootstrap_cfn/cloudformation.py
+++ b/bootstrap_cfn/cloudformation.py
@@ -24,9 +24,13 @@ class Cloudformation:
         return stack
 
     def update(self, stack_name, template_body):
-        stack = self.conn_cfn.update_stack(stack_name=stack_name,
-                                           template_body=template_body,
-                                           capabilities=['CAPABILITY_IAM'])
+        try:
+            stack = self.conn_cfn.update_stack(stack_name=stack_name,
+                                               template_body=template_body,
+                                               capabilities=['CAPABILITY_IAM'])
+        except boto.exception.BotoServerError:
+            return None
+
         return stack
 
     def delete(self, stack_name):

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -128,19 +128,117 @@ class ConfigParser(object):
     def process_update(self, templatebody):
         pristine = json.loads(templatebody)
 
+        #
+        # Prepare the new template.
+        #
+        #
+        # Here be dragons!
+        #
+        # the gateway attachment referencing the InternetGateway and
+        # VPC needs to exist before calling ec2() and elb() on the
+        # template.
+        #
+        # If you change the name of the VPC or the IGW on the CF
+        # template, the below will need to change to reflect the
+        # change.
+        #
         template = Template()
+        gw_attachment = VPCGatewayAttachment(
+            "AttachGateway",
+            VpcId=Ref('VPC'),
+            InternetGatewayId=Ref('InternetGateway'),
+            DependsOn='InternetGateway'
+        )
+        template.add_resource(gw_attachment)
+
+        if pristine['Resources'].get("DatabaseSG", None):
+            database_sg = SecurityGroup(
+                "DatabaseSG",
+                SecurityGroupIngress=[
+                    {"ToPort": 5432,
+                     "FromPort": 5432,
+                     "IpProtocol": "tcp",
+                     "CidrIp": FindInMap("SubnetConfig", "VPC", "CIDR")},
+                    {"ToPort": 1433,
+                     "FromPort": 1433,
+                     "IpProtocol": "tcp",
+                     "CidrIp": FindInMap("SubnetConfig", "VPC", "CIDR")},
+                    {"ToPort": 3306,
+                     "FromPort": 3306,
+                     "IpProtocol": "tcp",
+                     "CidrIp": FindInMap("SubnetConfig", "VPC", "CIDR")}
+                ],
+                VpcId=Ref("VPC"),
+                GroupDescription="SG for EC2 Access to RDS",
+                # translates to DependsOn=["AttachGateway"],
+                # but if not, ensure the tests have been updated too
+                DependsOn=[
+                    r.title
+                    for r in self._find_resources(
+                        template, "AWS::EC2::VPCGatewayAttachment")],
+            )
+            template.add_resource(database_sg)
+
         ec2 = self.ec2()
         map(template.add_resource, ec2)
 
         self.elb(template)
         template = json.loads(template.to_json())
 
+        # Copy new entries on top of the old ones
         temp = copy.deepcopy(pristine)
         for i in template['Resources']:
             temp['Resources'][i] = template['Resources'][i]
 
+        for i in template['Outputs']:
+            temp['Outputs'][i] = template['Outputs'][i]
+
+        #
+        # Delete stale LoadBalancer (ELBname) entries and
+        # SecurityGroups (name is configued on yaml) from CF Resources
+        #
+        # This cover cases where we rename elbs and security groups.
+        #
+        deleted_resources = utils.delete_stale_types(temp['Resources'], template['Resources'],
+                                                     'AWS::ElasticLoadBalancing::LoadBalancer')
+        ec2_sg_resources = utils.delete_stale_types(temp['Resources'], template['Resources'],
+                                                    'AWS::EC2::SecurityGroup')
+
+        # Manual cleanup
+        #
+        # Each old ELBname had a Policyname and a DNSname entry
+        # attached to the CFN but not directly referenced with
+        # 'Ref'. Remove them as well.
+        #
+        if deleted_resources is not None:
+            dns_cleanup = map(lambda i:i.replace('ELB', 'DNS'),  deleted_resources)
+            policy_cleanup = map(lambda i:i.replace('ELB', 'Policy'),  deleted_resources)
+
+            # Deleting resources.
+            for i in dns_cleanup + policy_cleanup:
+                try:
+                    del temp['Resources'][i]
+                except:
+                    logging.debug('{0} not found in Resources section'.format(i))
+
+            # Deleting outputs
+            for i in deleted_resources:
+                try:
+                    del temp['Outputs'][i]
+                except:
+                    logging.debug('{0} not found in Outputs section'.format(i))
+
+        logging.debug('Resources to be removed: {}'.format(deleted_resources, dns_cleanup, policy_cleanup, ec2_sg_resources))
+        logging.debug('Outputs to be removed: {}'.format(deleted_resources))
+
+        # convert the result to json
         result = json.dumps(temp, sort_keys=True, indent=None, separators=(',', ': '))
-        diff.diff(pristine, temp)
+
+
+        # print a non cloudformation context diff
+        changes = diff.diff(pristine, temp)
+        logging.debug(changes)
+
         return result
 
     def process(self):

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -124,6 +124,21 @@ class ConfigParser(object):
         self.application = application
         self.keyname = keyname
 
+    def process_update(self, templatebody):
+        bj = json.loads(templatebody)
+
+        template = Template()
+        ec2 = self.ec2()
+        map(template.add_resource, ec2)
+
+        template = json.loads(template.to_json())
+
+        for i in template['Resources']:
+            bj['Resources'][i] = template['Resources'][i]
+
+        result = json.dumps(bj, sort_keys=True, indent=None, separators=(',', ': '))
+        return result
+
     def process(self):
         template = self.base_template()
 

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -1,3 +1,4 @@
+import datadiff
 import copy
 import json
 import logging
@@ -187,10 +188,10 @@ class ConfigParser(object):
 
         # Copy new entries on top of the old ones
         temp = copy.deepcopy(pristine)
-        for i in template['Resources']:
+        for i in template.get('Resources', []):
             temp['Resources'][i] = template['Resources'][i]
 
-        for i in template['Outputs']:
+        for i in template.get('Outputs', []):
             temp['Outputs'][i] = template['Outputs'][i]
 
         #
@@ -231,14 +232,18 @@ class ConfigParser(object):
         logging.debug('Resources to be removed: {}'.format(deleted_resources, dns_cleanup, policy_cleanup, ec2_sg_resources))
         logging.debug('Outputs to be removed: {}'.format(deleted_resources))
 
-        # convert the result to json
-        result = json.dumps(temp, sort_keys=True, indent=None, separators=(',', ': '))
-
-
+        # Diff method 1
         # print a non cloudformation context diff
         changes = diff.diff(pristine, temp)
-        logging.debug(changes)
+        logging.info(changes)
 
+
+        # Diff method 2
+        changes = datadiff.diff(pristine, temp)
+        logging.info(changes)
+
+        # convert the result to json
+        result = json.dumps(temp, sort_keys=True, indent=None, separators=(',', ': '))
         return result
 
     def process(self):

--- a/bootstrap_cfn/diff.py
+++ b/bootstrap_cfn/diff.py
@@ -1,5 +1,5 @@
 import logging
-
+import difflib
 
 def diff(src, tgt, prefix=None, changes=None):
     t_src = type(src)
@@ -31,9 +31,17 @@ def diff(src, tgt, prefix=None, changes=None):
 def diffstr(src, tgt, prefix, changes):
     if src != tgt:
         if 'Properties.UserData.Fn::Base64' not in prefix:
-            logging.info("{0}: old value {1} changed to {2}".format(prefix, src, tgt))
+            logging.info("{0}: {1} to {2}".format(prefix, src, tgt))
         else:
-            logging.info("{0}: LaunchConfiguration changed. Please be careful".format(prefix))
+            all_lines = ''
+            logging.info("{0}: Launch configuration diff starts".format(prefix))
+            for i in difflib.unified_diff(src.splitlines(1),
+                                          tgt.splitlines(1),
+                                          fromfile='old launch configuration',
+                                          tofile='new launch configuration'):
+                all_lines = all_lines + i
+            logging.info("\n{}".format(all_lines))
+            logging.info("{0}: LaunchConfiguration diff ends. File is changing. Please be careful".format(prefix))
         changes = {"key": prefix, "old": src, "new": tgt}
     else:
         changes = None

--- a/bootstrap_cfn/diff.py
+++ b/bootstrap_cfn/diff.py
@@ -1,0 +1,110 @@
+import logging
+
+
+def diff(src, tgt, prefix=None, changes=None):
+    t_src = type(src)
+    t_dst = type(tgt)
+
+    if prefix is None:
+        prefix = "root"
+
+    if changes is None:
+        changes = []
+
+    if t_src != t_dst:
+        logging.info("src is {t1} while dst is {t2}".format(t1=t_src, t2=t_dst))
+        return False
+
+    if t_src is dict and t_dst is dict:
+        rc = diffdict(src, tgt, prefix, changes=changes)
+        if rc:
+            changes.append(rc)
+
+    if t_src in [str, unicode] and t_dst in [str, unicode]:
+        rc = diffstr(src, tgt, prefix, changes=changes)
+        if rc:
+            changes.append(rc)
+
+    return changes
+
+
+def diffstr(src, tgt, prefix, changes):
+    if src != tgt:
+        if 'Properties.UserData.Fn::Base64' not in prefix:
+            logging.info("{0}: old value {1} changed to {2}".format(prefix, src, tgt))
+        else:
+            logging.info("{0}: LaunchConfiguration changed. Please be careful".format(prefix))
+        changes = {"key": prefix, "old": src, "new": tgt}
+    else:
+        changes = None
+    return changes
+
+
+def difflist(src, tgt, prefix, changes):
+    s_src = src.sort()
+    s_tgt = tgt.sort()
+
+    # same lists
+    if s_src == s_tgt:
+        return None
+
+    only_src = s_src - s_tgt
+    if only_src != set():
+        logging.info("{0}: items removed from target: {1}".format(prefix, only_src))
+
+    #
+    # items only in dst
+    #
+    only_tgt = s_tgt - s_src
+    if only_tgt != set():
+        logging.info("{0}: items to target: {1}".format(prefix, only_tgt))
+
+    if only_tgt != set() or only_src != set():
+        changes.append({"key": prefix, "removed": only_src, "added": only_tgt})
+    #
+    # Recurse on common items
+    #
+    common = s_src.intersection(s_tgt)
+    if common == set():
+        return changes
+
+    for i in common:
+        diff(i, i,  prefix="{0}.{1}".format(prefix, i), changes=changes)
+
+
+def diffdict(src, tgt, prefix=None, changes=[]):
+    #
+    # We delete the Metadata key added by Cloudformation when a
+    # template has been edited in the editor
+    #
+    try:
+        del src['Metadata']
+        del tgt['Metadata']
+    except:
+        pass
+
+    s_src = set(src)
+    s_tgt = set(tgt)
+
+    #
+    # keys only in src
+    #
+    only_src = s_src - s_tgt
+    if only_src != set():
+        logging.info("{0}: keys removed from target: {1}".format(prefix, only_src))
+
+    #
+    # keys only in dst
+    #
+    only_tgt = s_tgt - s_src
+    if only_tgt != set():
+        logging.info("{0}: keys added to target: {1}".format(prefix, only_tgt))
+
+    if only_tgt != set() or only_src != set():
+        changes.append({"key": prefix, "removed": only_src, "added": only_tgt})
+    #
+    # Recurse on common keys
+    #
+    common = s_src.intersection(s_tgt)
+    for i in common:
+        diff(src[i], tgt[i],  prefix="{0}.{1}".format(prefix, i), changes=changes)

--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -717,7 +717,18 @@ def cfn_update(test=False):
     # Get online template
     response = cfn.conn_cfn.get_template(stack_name)
     body = response['GetTemplateResponse']['GetTemplateResult']['TemplateBody']
-    cfn.update(stack_name, cfn_config.process_update(body))
+    new_body = cfn_config.process_update(body)
+
+    x = raw_input("Are you sure you want to update the stack {}!? (y/n)\n".format(stack_name))
+    if x not in ['y', 'Y', 'Yes', 'yes']:
+        sys.exit(1)
+
+    rc = cfn.update(stack_name, cfn_config.process_update(body))
+    if not rc:
+        logger.critical("cfn_update: please check the logs for BotoServerError criticals")
+        logger.critical("cfn_update: this usually happens when cfn_update is ran but no changes are needed")
+        return
+
     tail(cfn, stack_name)
 
 @task

--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -730,6 +730,7 @@ def cfn_update(test=False):
         return
 
     tail(cfn, stack_name)
+    return True
 
 @task
 def cfn_create(test=False):

--- a/bootstrap_cfn/fab_tasks.py
+++ b/bootstrap_cfn/fab_tasks.py
@@ -705,6 +705,22 @@ def isactive():
 
 
 @task
+def cfn_update(test=False):
+    """
+    Update the AWS cloudformation stack.
+    """
+    _validate_fabric_env()
+    stack_name = get_stack_name(new=False)
+    cfn_config = get_config(called_by_cfn_create=True)
+
+    cfn = get_connection(Cloudformation)
+    # Get online template
+    response = cfn.conn_cfn.get_template(stack_name)
+    body = response['GetTemplateResponse']['GetTemplateResult']['TemplateBody']
+    cfn.update(stack_name, cfn_config.process_update(body))
+    tail(cfn, stack_name)
+
+@task
 def cfn_create(test=False):
     """
     Create the AWS cloudformation stack.

--- a/bootstrap_cfn/mime_packer.py
+++ b/bootstrap_cfn/mime_packer.py
@@ -46,7 +46,7 @@ def get_type(content, deftype):
 
 
 def pack(parts, opts={}):
-    outer = MIMEMultipart()
+    outer = MIMEMultipart(boundary='boostrapcfnboundary141')
 
     for arg in parts:
         if isinstance(arg, basestring):

--- a/bootstrap_cfn/mime_packer.py
+++ b/bootstrap_cfn/mime_packer.py
@@ -46,7 +46,10 @@ def get_type(content, deftype):
 
 
 def pack(parts, opts={}):
-    outer = MIMEMultipart(boundary='boostrapcfnboundary141')
+    #
+    # Do not change the boundary, as it'll break cfn_upadte
+    #
+    outer = MIMEMultipart(boundary='boostrapcfnboundary')
 
     for arg in parts:
         if isinstance(arg, basestring):

--- a/bootstrap_cfn/utils.py
+++ b/bootstrap_cfn/utils.py
@@ -121,6 +121,26 @@ def tail(stack, stack_name):
             seen.add(e.event_id)
         time.sleep(2)
 
+def delete_stale_types(old, new, cfn_type):
+    '''
+    Given two dicts and a type, remove the keys that don't exist in
+    new from old.
+    '''
+    test = lambda x: True if x.get('Type', None) == cfn_type else False
+    old_outs = [k for k,v in old.iteritems() if test(v)]
+    new_outs = [k for k,v in new.iteritems() if test(v)]
+
+    old_outs = set(old_outs)
+    new_outs = set(new_outs)
+
+    # only in old means they are stale and needs to be deleted
+    diff = old_outs - new_outs
+
+    # Delete the actual things referenced...
+    for i in diff:
+        del old[i]
+    return diff
+
 
 def get_events(stack, stack_name):
     """Get the events in batches and return in chronological order"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Fabric==1.10.1
 PyYAML==3.11
 boto==2.36.0
 boto3==1.2.2
+datadiff==2.0.0
 dnspython==1.12.0
 mock==1.0.1
 netaddr==0.7.18


### PR DESCRIPTION
Partial support for cloudformation updates is now supported on the EC2 and ELB sections of the configuration file:

```fab application:courtfinder aws:my_project_prod environment:dev config:/path/to/courtfinder-dev.yaml tag:[tag_name] cfn_update```

Note: Running this command will show you some structured output of what
changes and how. Also a unified diff is printed on output between the
old and the new Launch Configuration sections. Although we have gone
to great lengths with this command, it can result in destructive
operations, particularly if one reduced the desired/max/min capacities
of the Auto Scaling Group.

Note #2: In order to test this, you will have to set PYTHONPATH pointing to this branch of the PR and to bootstrap-salt's version https://github.com/ministryofjustice/bootstrap-salt/pull/80

Note #3: The fabfile.py of the relevant -deploy repo should contain a line like this: ```from bootstrap_salt.fab_tasks import cfn_create, cfn_delete, cfn_update```


