### PR TITLE
Add DNS records for stacks created by old bcfn

### DIFF
--- a/bootstrap_cfn/errors.py
+++ b/bootstrap_cfn/errors.py
@@ -50,9 +50,9 @@ class ZoneRoute53RecordNotFoundError(BootstrapCfnError):
 
 
 class DNSRecordNotFoundError(BootstrapCfnError):
-    def __init__(self, zone_name):
+    def __init__(self, record):
         msg = ("Could not find a dns record for zone name '{}'. "
-               "Please check that this record exists".format(zone_name))
+               "Please check that this record exists".format(record))
         super(DNSRecordNotFoundError, self).__init__(msg)
 
 

--- a/bootstrap_cfn/utils.py
+++ b/bootstrap_cfn/utils.py
@@ -132,7 +132,10 @@ def get_events(stack, stack_name):
         except:
             break
         event_list.append(events)
-        if events.next_token is None:
+        try:
+            if events.next_token is None:
+                break
+        except AttributeError:
             break
         next = events.next_token
         time.sleep(1)

--- a/tests/test_r53.py
+++ b/tests/test_r53.py
@@ -26,7 +26,7 @@ class BootstrapCfnR53TestCase(unittest.TestCase):
         r53_mock.return_value = r53_connect_result
         boto.route53.connect_to_region = r53_mock
         r = r53.R53(self.env.aws_profile)
-        x = r.update_dns_record('blah/blah', 'x.y', 'A', '1.1.1.1')
+        x = r.update_dns_record('zone_name','blah/blah', 'x.y', 'A', '1.1.1.1')
         self.assertTrue(x)
 
     def test_delete_dns_record(self):
@@ -35,7 +35,7 @@ class BootstrapCfnR53TestCase(unittest.TestCase):
         r53_mock.return_value = r53_connect_result
         boto.route53.connect_to_region = r53_mock
         r = r53.R53(self.env.aws_profile)
-        x = r.delete_dns_record('blah/blah', 'x.y', 'A', '1.1.1.1')
+        x = r.delete_dns_record('zone_name','blah/blah', 'x.y', 'A', '1.1.1.1')
         self.assertTrue(x)
 
     def test_get_hosted_zone_id(self):


### PR DESCRIPTION
- Stacks created with old bootstrap-cfn only have one set of DNS records which we called "active" records. In bootstrap-cfn 1.x.x, we started to support multiple stacks by switching tagged DNS records to "active". This PR is to add the missing DNS records in stacks with old bootstrap-cfn so that they could use 1.x.x features.

- To review this PR
  - create a test stack with old bootstrapcfn<1.0.0
  - pip install the latest bootstrap-cfn; run `fab set_active_stack:active` which should break or `fab get_stack_list` should only return active records
  - install this branch to your local virtualenv via `pip install -U git+https://github.com/ministryofjustice/bootstrap-cfn.git@add_dns_records_for_old_bcfn` 
  - run `support_old_bootstrap_cfn`  in fab command, give it a tag
  - then `get_active_stack` should return the stack you altered; if not, run `set_active_stack:[tag-name]`; get_stack_list should list records with the [tag-name] you specified earlier as well.

- support_old_bootstrap_cfn structures:
  - if stack exist:
    ----- TXT records ----
    - if active records do not exist:
      - add active records; continue
    - if tagged stack records do not exist:
      - add stack records

    ---- Alias (ELB) records ----
    - if active records do not exist:
      - throw exception -- add manually
    - if tagged stack records do not exist:
      - add stack records

- There are also some fixes on code style mostly with r53.py because we have been using a mixture of record name with "dsd.io" and without in the parameters, which is confusing sometimes.