### PR TITLE
Fix backward compatibility for dns update

### DIFF
--- a/bootstrap_cfn/r53.py
+++ b/bootstrap_cfn/r53.py
@@ -41,7 +41,8 @@ class R53(object):
             zone = zone['GetHostedZoneResponse']['HostedZone']['Id']
             return zone.replace('/hostedzone/', '')
 
-    def update_dns_record(self, zone_name, zone_id, record, record_type, record_value, is_alias=False, dry_run=False):
+    def update_dns_record(self, zone_id, record, record_type, record_value,
+                          is_alias=False, zone_name=None, dry_run=False):
         """
         Updates a dns record in route53
         Args:
@@ -55,8 +56,10 @@ class R53(object):
             dry_run:
         Returns True if update successful or raises an exception if not
         """
-        zone_name = conform_with_fqdn(zone_name)
-        record_name = "{}.{}".format(record, zone_name)
+        if zone_name:
+            record_name = conform_with_fqdn("{}.{}".format(record, zone_name))
+        else:
+            record_name = conform_with_fqdn(record)
         changes = boto.route53.record.ResourceRecordSets(self.conn_r53, zone_id)
         change = changes.add_change("UPSERT", record_name, record_type, ttl=60)
         if is_alias:

--- a/tests/test_r53.py
+++ b/tests/test_r53.py
@@ -26,7 +26,7 @@ class BootstrapCfnR53TestCase(unittest.TestCase):
         r53_mock.return_value = r53_connect_result
         boto.route53.connect_to_region = r53_mock
         r = r53.R53(self.env.aws_profile)
-        x = r.update_dns_record('zone_name', 'blah/blah', 'x.y', 'A', '1.1.1.1')
+        x = r.update_dns_record('blah/blah', 'x.y', 'A', '1.1.1.1', zone_name='zone_name')
         self.assertTrue(x)
 
     def test_delete_dns_record(self):


### PR DESCRIPTION
Amends the recent changes in r53 update_dns_record so that they do
not change the method signature, which broke older clients/fabfiles.
Passes elb hosted zones in maintenance as well, although the
maintenance feature has not necessarily been fully tested in the
current version of bootstrap-cfn. Tests updated.