### PR TITLE
Allow multi-part policies on aditional s3 buckets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -586,6 +586,8 @@ For example, the sample custom policy defined in this `json file <https://github
     
 We can also supply a list of buckets to create a range of s3 buckets, these require a name. 
 These entries can also specify their own policies or use the default, vpc limited one.
+Policies for these additional buckets can be provided as an individual policy document the same as
+for the static bucket or a list as in this `example multi-part policy <https://github.com/ministryofjustice/bootstrap-cfn/blob/master/tests/sample-s3-additional-bucket-multi-part-custom-policy.json>`_
 
 .. code:: yaml
 
@@ -602,6 +604,7 @@ These entries can also specify their own policies or use the default, vpc limite
            lifecycles:
              /:
              expirationdays: 5
+           policy: tests/sample-s3-additional-bucket-multi-part-custom-policy.json
 
 The outputs of these buckets will be the bucket name postfixed by 'BucketName', ie, mybucketidBucketName. Additionally, and as shown above, one can define a list of Lifecycle rules on a per prefix basis. If a root rule is defined, the rest of the rules are ignored.
 

--- a/bootstrap_cfn/config.py
+++ b/bootstrap_cfn/config.py
@@ -546,10 +546,13 @@ class ConfigParser(object):
                     }
                 }
             }
+
+        policy = policy if isinstance(policy, list) else [policy]
+
         bucket_policy = BucketPolicy(
             "{}Policy".format(bucket_name),
             Bucket=Ref(bucket),
-            PolicyDocument={"Statement": [policy]},
+            PolicyDocument={"Statement": policy},
         )
         # Add the bucket name to the list of cloudformation
         # outputs

--- a/tests/sample-s3-additional-bucket-custom-policy.json
+++ b/tests/sample-s3-additional-bucket-custom-policy.json
@@ -1,0 +1,6 @@
+{
+  "Action": ["s3:Get*", "s3:Put*", "s3:List*", "s3:Delete*"],
+  "Resource": "arn:aws:s3:::testbucket/*",
+  "Effect": "Allow",
+  "Principal": {"AWS": "*"}
+}

--- a/tests/sample-s3-additional-bucket-multi-part-custom-policy.json
+++ b/tests/sample-s3-additional-bucket-multi-part-custom-policy.json
@@ -1,0 +1,22 @@
+[
+  {
+    "Action": ["s3:Get*", "s3:Put*", "s3:List*", "s3:Delete*"],
+    "Resource": "arn:aws:s3:::testbucket/*",
+    "Effect": "Allow",
+    "Condition": {
+      "StringEquals": {
+        "aws:sourceVpc": {"Ref": "VPC"}
+      }
+    }
+  },
+  {
+    "Action": ["s3:Put*"],
+    "Resource": "arn:aws:s3:::testbucket/*",
+    "Effect": "Deny",
+    "Condition": {
+      "StringNotEquals": {
+        "s3:x-amz-server-side-encryption": "AES256"
+      }
+    }
+  }
+]


### PR DESCRIPTION
AIM policy documents are made up of a list of policy statements. Currently bootstrap-cfn only allows a single custom policy for an S3 bucket. This change allows a list of custom policies to be provided. Backwards compatibility is maintained by allowing either a single policy dict or a list of policies.

I have only implemented this on the additional s3 buckets because the static buckets are for a specific use case and should be kept as simple as possible. Do you think it would make more sense to implement it the same for the static bucket and additional buckets?