### PR TITLE
WIP: Allow logical name to be set on additional buckets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -603,6 +603,17 @@ These entries can also specify their own policies or use the default, vpc limite
              /:
              expirationdays: 5
 
+A logical name can be provided for bucket which need not be unique. This can be useful when
+there is a bucket for a given use in each environment. Fabric tasks can then be written against
+the logical name as seen in the `template deploy <https://github.com/ministryofjustice/template-deploy/blob/master/fabfile.py>`_ :code:`upload_assets` task.
+
+.. code:: yaml
+
+   s3:
+      buckets:
+         - name: mybucket-dev
+           logical-name: mybucket
+
 The outputs of these buckets will be the bucket name postfixed by 'BucketName', ie, mybucketidBucketName. Additionally, and as shown above, one can define a list of Lifecycle rules on a per prefix basis. If a root rule is defined, the rest of the rules are ignored.
 
 Currently, only non-versioned buckets are supported. 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -458,6 +458,37 @@ class TestConfigParser(unittest.TestCase):
                 self._resources_to_dict([static_bp, bucket, bucket1, bucket_policy1,
                                          bucket2, bucket_policy2, bucket3, bucket_policy3]))
 
+    def test_s3_additional_bucket_override_logical_name(self):
+        conf_under_test = {
+            'static-bucket-name': 'moj-test-dev-static',
+            'buckets': [
+                {
+                    'name': 'testbucket-dev',
+                    'logical-name': 'testbucket'
+                }
+            ]
+        }
+
+        expected_bucket_config = {
+            'Properties': {
+                'AccessControl': 'BucketOwnerFullControl',
+                'BucketName': 'testbucket-dev',
+            },
+            'Type': 'AWS::S3::Bucket',
+        }
+
+        project_config = ProjectConfig('tests/sample-project.yaml', 'dev')
+        project_config.config['s3'] = conf_under_test
+        config = ConfigParser(project_config.config, 'my-stack-name')
+
+        template = Template()
+        config.s3(template)
+        resources = template.resources.values()
+
+        s3_cfg = self._resources_to_dict(resources)
+
+        compare(expected_bucket_config, s3_cfg['testbucket'])
+
     def test_rds(self):
 
         template = Template()


### PR DESCRIPTION
AWS allows buckets to have a logical name as well as a physical name. This feature is used by `upload_assets` to make it easier to perform actions on a kind of bucket within an environment. This is also useful for additional S3 buckets where we need a different bucket per environment.

Backwards compatibility is maintained by introducing an additional yaml key for the `logical-name` which overrides the resource name. If it's not set the resource name reverts to the bucket name.