### PR TITLE
Support alternative ACM domain domain validation domains

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ script:
   - |
     set -e -o pipefail;
     if [ "$TRAVIS_PULL_REQUEST" != "false" ]
-      then git diff $TRAVIS_COMMIT_RANGE !(docs) | flake8 --diff;
-      else git fetch -q origin master:origin/master && git diff origin/master... !(docs) | flake8 --diff
+      then git diff $TRAVIS_COMMIT_RANGE !(docs) | flake8 --diff --exclude tests/cloudformation/*;
+      else git fetch -q origin master:origin/master && git diff origin/master... !(docs) | flake8 --diff --exclude tests/cloudformation/*
     fi
 
   # Then run the tests

--- a/README.rst
+++ b/README.rst
@@ -493,6 +493,9 @@ This section defines certificates for the AWS Certificate Manager. For verificat
                     - <alternative_name_1>
                     - <alternative_name_2>
                 validation_domain: <validation_domain>  # (optional) The domain name the verfication email should go to. The default is the domain name.
+                domain_validation_options:              # (optional) override validation_domain for specific domain names
+                  - domain_name: <alternative_name>
+                    validation_domain: <alternative_validation_domain>
                 tags:
                     <key>: <val>                      # (optional) Dictionary of keypairs to tag the resource with.
 
@@ -504,8 +507,11 @@ For example,
           mycert:
             domain: helloworld.test.dsd.io
             subject_alternative_names:
-                - goodbye.test.dsd.io
+                - goodbye.test.somewhere.io
             validation_domain: dsd.io
+            domain_validation_options:
+              - domain_name: goodbye.test.somewhere.io
+                validation_domain: somewhere.io
             tags:
                 site: testsite
 

--- a/tests/cloudformation/sample-project_acm.yaml
+++ b/tests/cloudformation/sample-project_acm.yaml
@@ -1,4 +1,5 @@
 # noqa
+---
 dev:
   ec2:
     tags:
@@ -35,9 +36,12 @@ dev:
     mycert:
       domain: helloworld.test.dsd.io
       subject_alternative_names:
-          - goodbye.test.dsd.io
-          - hello_again.test.dsd.io
+        - goodbye.test.somewhere.io
+        - hello_again.subdomain.dsd.io
       validation_domain: dsd.io
+      domain_validation_options:
+        - domain_name: goodbye.test.somewhere.io
+          validation_domain: somewhere.io
       tags:
         test_key1: test_value_1
         test_key2: test_value_2

--- a/tests/test_acm.py
+++ b/tests/test_acm.py
@@ -35,29 +35,34 @@ class TestConfigParser(unittest.TestCase):
             {'Key': 'test_key1', 'Value': 'test_value_1'},
             {'Key': 'test_key2', 'Value': 'test_value_2'}
         ]
-        subject_alternative_names = ['goodbye.test.dsd.io', 'hello_again.test.dsd.io']
+        subject_alternative_names = ['goodbye.test.somewhere.io', 'hello_again.subdomain.dsd.io']
 
+        # The main domain should use validation_domain,
+        # 'goodbye.test.somewhere.io' should use the domain_validation_options
+        # to validate on somewhere.io.
+        # 'hello_again.subdomain.dsd.io' has no validation_options so should
+        # default to the validation_domain
         domain_validation_options = [
             DomainValidationOption(
                 DomainName=domain_name,
                 ValidationDomain=validation_domain
             ),
             DomainValidationOption(
-                DomainName=subject_alternative_names[0],
-                ValidationDomain=validation_domain
+                DomainName='goodbye.test.somewhere.io',
+                ValidationDomain='somewhere.io'
             ),
             DomainValidationOption(
-                DomainName=subject_alternative_names[1],
+                DomainName='hello_again.subdomain.dsd.io',
                 ValidationDomain=validation_domain
             )
         ]
         ACMCertificate = Certificate(
-                certificate_name,
-                DomainName=domain_name,
-                SubjectAlternativeNames=subject_alternative_names,
-                DomainValidationOptions=domain_validation_options,
-                Tags=tags
-            )
+            certificate_name,
+            DomainName=domain_name,
+            SubjectAlternativeNames=subject_alternative_names,
+            DomainValidationOptions=domain_validation_options,
+            Tags=tags
+        )
         certificate_cfg = [config_parser._get_acm_certificate(certificate_name)]
         expected = [ACMCertificate]
         compare(self._resources_to_dict(expected),
@@ -80,12 +85,12 @@ class TestConfigParser(unittest.TestCase):
             ValidationDomain=domain_name
         )
         ACMCertificate = Certificate(
-                parsed_certificate_name,
-                DomainName=domain_name,
-                SubjectAlternativeNames=subject_alternative_names,
-                DomainValidationOptions=[domain_validation_options],
-                Tags=tags
-            )
+            parsed_certificate_name,
+            DomainName=domain_name,
+            SubjectAlternativeNames=subject_alternative_names,
+            DomainValidationOptions=[domain_validation_options],
+            Tags=tags
+        )
         certificate_cfg = [config_parser._get_acm_certificate(certificate_name)]
         expected = [ACMCertificate]
         compare(self._resources_to_dict(expected),


### PR DESCRIPTION
This change adds support for the domain_validation_options setting.
This means that any subject_alternative_names can have their
validation_domain explicitly overriden.